### PR TITLE
[WIP] Prototype for storing encrypted columns in a vault

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'puma',                 '~> 3.0'
 gem 'rack-cors',            '>= 0.4.1'
 gem 'rails',                '~> 5.2.2'
 gem 'sprockets',            '~> 4.0'
+gem "vault",                '~> 0.1'
 
 group :development, :test do
   gem 'rubocop',             '~>0.69.0', :require => false

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,5 +1,9 @@
 class Authentication < ApplicationRecord
-  include PasswordConcern
+  if ENV["VAULT_ADDR"].present?
+    include VaultPasswordConcern
+  else
+    include PasswordConcern
+  end
   include TenancyConcern
   encrypt_column :password
 

--- a/app/models/concerns/vault_password_concern.rb
+++ b/app/models/concerns/vault_password_concern.rb
@@ -17,6 +17,7 @@ module VaultPasswordConcern
 
   def load_encrypted_columns
     self.class.encrypted_columns.each do |col|
+      send("#{col}_encrypted=", read_attribute(col))
       write_attribute(col, read_from_vault(col))
     end
   end
@@ -36,7 +37,7 @@ module VaultPasswordConcern
   end
 
   def read_from_vault(attr)
-    Vault.kv("secret").read(vault_key).try(:data)[attr.to_sym]
+    Vault.kv("secret").read(vault_key).try(:data).try(:[], attr.to_sym)
   end
 
   def write_to_vault(attr, val)

--- a/app/models/concerns/vault_password_concern.rb
+++ b/app/models/concerns/vault_password_concern.rb
@@ -1,0 +1,56 @@
+module VaultPasswordConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_find  :load_encrypted_columns
+    before_save :process_encrypted_columns
+    after_save  :save_encrypted_columns
+
+    class_attribute :encrypted_columns
+    self.encrypted_columns = []
+
+    Vault.address = "http://127.0.0.1:8200"      # Also reads from ENV["VAULT_ADDR"]
+    Vault.token   = "s.D1HV4tdV2TeaAJO12njDN1GH" # Also reads from ENV["VAULT_TOKEN"]
+  end
+
+  private
+
+  def load_encrypted_columns
+    self.class.encrypted_columns.each do |col|
+      write_attribute(col, read_from_vault(col))
+    end
+  end
+
+  def process_encrypted_columns
+    self.class.encrypted_columns.each do |col|
+      send("#{col}_encrypted=", read_attribute(col)) # copy unencrypted value
+      write_attribute(col, "******")                 # obfuscate  encrypted column
+    end
+  end
+
+  def save_encrypted_columns
+    self.class.encrypted_columns.each do |col|
+      write_to_vault(col, send("#{col}_encrypted"))
+      write_attribute(col, send("#{col}_encrypted")) # put unencrypted value back in column
+    end
+  end
+
+  def read_from_vault(attr)
+    Vault.kv("secret").read(vault_key).try(:data)[attr.to_sym]
+  end
+
+  def write_to_vault(attr, val)
+    Vault.kv("secret").write(vault_key, attr.to_sym => val)
+  end
+
+  def vault_key
+    "#{self.class.table_name}_#{id}"
+  end
+
+  module ClassMethods
+    def encrypt_column(column)
+      encrypted_columns << column.to_s
+      class_eval { attr_accessor "#{column}_encrypted" }
+    end
+  end
+end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,54 @@
+describe Authentication do
+  describe VaultPasswordConcern do
+    before do
+      stub_const("ENV", "VAULT_ADDR" => "http://127.0.0.1:8200")
+      Object.send(:remove_const, :Authentication) if Module.const_defined?(:Authentication)
+      load "authentication.rb"
+    end
+
+    after do
+      stub_const("ENV", "VAULT_ADDR" => nil)
+      Object.send(:remove_const, :Authentication) if Module.const_defined?(:Authentication)
+      load "authentication.rb"
+    end
+
+    let(:tenant)      { Tenant.create!(:name => "default", :external_tenant => "123456") }
+    let(:source_type) { SourceType.create!(:name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
+    let(:source)      { Source.create!(:name => "My Source", :source_type => source_type, :tenant => tenant) }
+    let(:endpoint)    { Endpoint.create!(:source => source, :tenant => tenant) }
+
+    context "creating an authentication" do
+      let(:password)  { "smartvm" }
+      let(:auth)      { Authentication.create!(:resource => endpoint, :password => password, :tenant => tenant) }
+      let(:vault_key) { "authentications_99" }
+      let(:dbl)       { double("Vault::KV") }
+
+
+      it "should write unencrypted password to the vault" do
+        allow_any_instance_of(Authentication).to receive(:vault_key).and_return(vault_key)
+        allow(Vault).to receive(:kv).with("secret").and_return(dbl)
+
+        expect(dbl).to receive(:write).with(vault_key, :password => password)
+        expect(auth.password).to eq(password)
+      end
+
+      it "obfuscate password in the database" do
+        allow_any_instance_of(Authentication).to receive(:vault_key).and_return(vault_key)
+        allow(Vault).to receive(:kv).with("secret").and_return(dbl)
+        allow(dbl).to receive(:write)
+        expect(dbl).to receive(:read)
+        expect(Authentication.find(auth.id).password_encrypted).to eq("******")
+      end
+    end
+
+    context "an existing authentication" do
+      it "retrieves password from vault" do
+        # TODO
+      end
+
+      it "no vault entry returns nil for password" do
+        # TODO
+      end
+    end
+  end
+end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,4 +1,8 @@
 describe Authentication do
+  describe PasswordConcern do
+    # TODO
+  end
+
   describe VaultPasswordConcern do
     let(:test_vault_password_class) do
       Class.new(ActiveRecord::Base) do
@@ -10,26 +14,25 @@ describe Authentication do
       end
     end
 
-    let(:tenant)      { Tenant.create!(:name => "default", :external_tenant => "123456") }
+    let(:tenant) { Tenant.create!(:name => "default", :external_tenant => "123456") }
+    let(:dbl)    { double("Vault::KV") }
 
     context "creating an authentication" do
       let(:password)  { "smartvm" }
       let(:auth)      { test_vault_password_class.create!(:password => password, :tenant => tenant) }
       let(:vault_key) { "authentications_99" }
-      let(:dbl)       { double("Vault::KV") }
 
-
-      it "should write unencrypted password to the vault" do
+      before do
         allow_any_instance_of(test_vault_password_class).to receive(:vault_key).and_return(vault_key)
         allow(Vault).to receive(:kv).with("secret").and_return(dbl)
+      end
 
+      it "should write unencrypted password to the vault" do
         expect(dbl).to receive(:write).with(vault_key, :password => password)
         expect(auth.password).to eq(password)
       end
 
       it "obfuscate password in the database" do
-        allow_any_instance_of(test_vault_password_class).to receive(:vault_key).and_return(vault_key)
-        allow(Vault).to receive(:kv).with("secret").and_return(dbl)
         allow(dbl).to receive(:write)
         expect(dbl).to receive(:read)
         expect(test_vault_password_class.find(auth.id).password_encrypted).to eq("******")
@@ -37,12 +40,31 @@ describe Authentication do
     end
 
     context "an existing authentication" do
+      let(:password)      { "smartervm" }
+      let(:existing_auth) { test_vault_password_class.create!(:password => password, :tenant => tenant) }
+      let(:vault_key)     { "authentications_100" }
+      let(:vault_secret)  { double("Vault::Secret") }
+
+      before do
+        allow_any_instance_of(test_vault_password_class).to receive(:vault_key).and_return(vault_key)
+        allow(Vault).to receive(:kv).with("secret").and_return(dbl)
+        allow(dbl).to receive(:write).with(vault_key, :password => password)
+        allow(dbl).to receive(:read).with(vault_key).and_return(vault_secret)
+      end
+
       it "retrieves password from vault" do
-        # TODO
+        allow(vault_secret).to receive(:data).and_return(:password => password)
+
+        auth = test_vault_password_class.find(existing_auth.id)
+        expect(auth.password).to eq(password)
+        expect(auth.password_encrypted).to eq("******")
       end
 
       it "no vault entry returns nil for password" do
-        # TODO
+        allow(vault_secret).to receive(:data).and_return(nil)
+
+        auth = test_vault_password_class.find(existing_auth.id)
+        expect(auth.password).to eq(nil)
       end
     end
   end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,31 +1,26 @@
 describe Authentication do
   describe VaultPasswordConcern do
-    before do
-      stub_const("ENV", "VAULT_ADDR" => "http://127.0.0.1:8200")
-      Object.send(:remove_const, :Authentication) if Module.const_defined?(:Authentication)
-      load "authentication.rb"
-    end
-
-    after do
-      stub_const("ENV", "VAULT_ADDR" => nil)
-      Object.send(:remove_const, :Authentication) if Module.const_defined?(:Authentication)
-      load "authentication.rb"
+    let(:test_vault_password_class) do
+      Class.new(ActiveRecord::Base) do
+        def self.name; "TestClass"; end
+        self.table_name = "authentications"
+        include TenancyConcern
+        include VaultPasswordConcern
+        encrypt_column :password
+      end
     end
 
     let(:tenant)      { Tenant.create!(:name => "default", :external_tenant => "123456") }
-    let(:source_type) { SourceType.create!(:name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
-    let(:source)      { Source.create!(:name => "My Source", :source_type => source_type, :tenant => tenant) }
-    let(:endpoint)    { Endpoint.create!(:source => source, :tenant => tenant) }
 
     context "creating an authentication" do
       let(:password)  { "smartvm" }
-      let(:auth)      { Authentication.create!(:resource => endpoint, :password => password, :tenant => tenant) }
+      let(:auth)      { test_vault_password_class.create!(:password => password, :tenant => tenant) }
       let(:vault_key) { "authentications_99" }
       let(:dbl)       { double("Vault::KV") }
 
 
       it "should write unencrypted password to the vault" do
-        allow_any_instance_of(Authentication).to receive(:vault_key).and_return(vault_key)
+        allow_any_instance_of(test_vault_password_class).to receive(:vault_key).and_return(vault_key)
         allow(Vault).to receive(:kv).with("secret").and_return(dbl)
 
         expect(dbl).to receive(:write).with(vault_key, :password => password)
@@ -33,11 +28,11 @@ describe Authentication do
       end
 
       it "obfuscate password in the database" do
-        allow_any_instance_of(Authentication).to receive(:vault_key).and_return(vault_key)
+        allow_any_instance_of(test_vault_password_class).to receive(:vault_key).and_return(vault_key)
         allow(Vault).to receive(:kv).with("secret").and_return(dbl)
         allow(dbl).to receive(:write)
         expect(dbl).to receive(:read)
-        expect(Authentication.find(auth.id).password_encrypted).to eq("******")
+        expect(test_vault_password_class.find(auth.id).password_encrypted).to eq("******")
       end
     end
 


### PR DESCRIPTION
This is a prototype for using [Hashicorp vault](https://www.hashicorp.com/products/vault) for storing passwords instead of the DB.

ToDo:
- [ ] Tests
- [ ] Add support for vault namespace/engine, currently hardcoded to "secret"
- [ ] Migration of existing passwords
- [ ] Install and configure a vault. I'm testing this locally

