### PR TITLE
Update rack-cors to at least 1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"
 gem 'more_core_extensions', '~> 3.5'
 gem 'pg',                   '~> 1.0', :require => false
 gem 'puma',                 '~> 3.0'
-gem 'rack-cors',            '>= 0.4.1'
+gem 'rack-cors',            '>= 1.0.4', '~> 1.0'
 gem 'rails',                '~> 5.2.2'
 gem 'sprockets',            '~> 4.0'
 


### PR DESCRIPTION
Fixes a hakiri security warning about file access