### PR TITLE
Add receptor id field to Ansible Tower

### DIFF
--- a/db/seeds/source_types.rb
+++ b/db/seeds/source_types.rb
@@ -130,6 +130,8 @@ ansible_tower_json_schema = {
       {:component => "text-field", :name => "url", :label => "URL", :validate => [{:type => "url-validator"}]},
       {:component => "switch-field", :name => "endpoint.verify_ssl", :label => "Verify SSL"},
       {:component => "text-field", :name => "endpoint.certificate_authority", :label => "Certificate Authority", :condition => {:when => "endpoint.verify_ssl", :is => true}},
+      {:component => "switch-field", :name => "platform_receptor", :label => "Use Platform Receptor and PKI (?)"},
+      {:component => "text-field", :name => "endpoint.receptor_node", :label => "Receptor ID"},
     ]
   }
 }


### PR DESCRIPTION
**Description**

- Adds a switch field with `Use Platform Receptor and PKI (?)`
- Adds a text input with Receptor ID sent to endpoint's endpoint as a `resource_node`