### PR TITLE
Adding the POST /api/sources/:source_id/check_availability action

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -15,6 +15,23 @@ module Api
 
         render :json => source, :status => :created, :location => instance_link(source)
       end
+
+      def check_availability
+        source = Source.find(params[:source_id])
+
+        Sources::Api::Messaging.client.publish_topic(
+          :service => "platform.topological-inventory.operations-#{source.source_type.name}",
+          :event   => "Source.availability_check",
+          :payload => {
+            :params => {
+              :source_id       => source.id,
+              :external_tenant => source.tenant.external_tenant
+            }
+          }
+        )
+
+        render :json => source, :status => :accepted
+      end
     end
   end
 end

--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -24,7 +24,7 @@ module Api
           :event   => "Source.availability_check",
           :payload => {
             :params => {
-              :source_id       => source.id,
+              :source_id       => source.id.to_s,
               :external_tenant => source.tenant.external_tenant
             }
           }

--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -30,7 +30,7 @@ module Api
           }
         )
 
-        render :json => source, :status => :accepted
+        render :json => {}, :status => :accepted
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
         resources :sources, :only => [:index]
       end
       resources :sources,         :only => [:create, :destroy, :index, :show, :update] do
+        post "check_availability", :to => "sources#check_availability", :action => "check_availability"
         resources :applications, :only => [:index]
         resources :application_types, :only => [:index]
         resources :endpoints, :only => [:index]

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -12,18 +12,7 @@ module Sources
 
         publish_opts[:headers] = headers if headers
 
-        messaging_client.publish_topic(publish_opts)
-      end
-
-      private_class_method def self.messaging_client
-        require "manageiq-messaging"
-
-        @messaging_client ||= ManageIQ::Messaging::Client.open(
-          :protocol => :Kafka,
-          :host     => ENV["QUEUE_HOST"] || "localhost",
-          :port     => ENV["QUEUE_PORT"] || "9092",
-          :encoding => "json"
-        )
+        Messaging.client.publish_topic(publish_opts)
       end
     end
   end

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -1,0 +1,16 @@
+module Sources
+  module Api
+    module Messaging
+      def self.client
+        require "manageiq-messaging"
+
+        @client ||= ManageIQ::Messaging::Client.open(
+          :protocol => :Kafka,
+          :host     => ENV["QUEUE_HOST"] || "localhost",
+          :port     => ENV["QUEUE_PORT"] || "9092",
+          :encoding => "json"
+        )
+      end
+    end
+  end
+end

--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -41,21 +41,14 @@ class OpenapiGenerator < Insights::API::Common::OpenApi::Generator
         ],
         "responses"   => {
           "202" => {
-            "description" => "Availability Check Accepted",
+            "description" => "Availability Check Accepted"
+          },
+          "404" => {
+            "description" => "Not found",
             "content"     => {
               "application/json" => {
                 "schema" => {
-                  "$ref" => "#/components/schemas/Source"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorNotFound"
+                  "$ref" => "#/components/schemas/ErrorNotFound"
                 }
               }
             }

--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -26,6 +26,44 @@ class OpenapiGenerator < Insights::API::Common::OpenApi::Generator
       )
     end
   end
+
+  def handle_custom_route_action(route_action, verb, primary_collection)
+    case [primary_collection, verb, route_action]
+    when ["Source", "post", "CheckAvailability"]
+      {
+        "summary"     => "Checks Availability of a Source",
+        "operationId" => "checkAvailabilitySource",
+        "description" => "Checks Availability of a Source",
+        "parameters"  => [
+          {
+            "$ref" => "#/components/parameters/ID"
+          }
+        ],
+        "responses"   => {
+          "202" => {
+            "description" => "Availability Check Accepted",
+            "content"     => {
+              "application/json" => {
+                "schema" => {
+                  "$ref" => "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+  end
 end
 
 namespace :openapi do

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1096,6 +1096,40 @@
         }
       }
     },
+    "/sources/{id}/check_availability": {
+      "post": {
+        "summary": "Checks Availability of a Source",
+        "operationId": "checkAvailabilitySource",
+        "description": "Checks Availability of a Source",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Availability Check Accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/sources/{id}/endpoints": {
       "get": {
         "summary": "List Endpoints for Source",

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1108,14 +1108,7 @@
         ],
         "responses": {
           "202": {
-            "description": "Availability Check Accepted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Source"
-                }
-              }
-            }
+            "description": "Availability Check Accepted"
           },
           "404": {
             "description": "Not found",
@@ -1311,6 +1304,9 @@
       "ApplicationType": {
         "type": "object",
         "properties": {
+          "availability_check_url": {
+            "type": "string"
+          },
           "created_at": {
             "format": "date-time",
             "readOnly": true,

--- a/spec/controllers/api/v1x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v1x0/endpoints_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1x0::EndpointsController, :type => :request do
 
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   it "post /endpoints creates an Endpoint" do

--- a/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::DestroyMixin do
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
     end
 
     it "Primary Collection: delete /sources/:id destroys a Source" do

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::UpdateMixin do
 
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
     end
 
     it "patch /sources/:id updates a Source" do

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v1.0 - Authentications") do
   let(:client) { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe("v1.0 - SourceTypes") do
       let(:client) { instance_double("ManageIQ::Messaging::Client") }
       before do
         allow(client).to receive(:publish_topic)
-        allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+        allow(Sources::Api::Messaging).to receive(:client).and_return(client)
       end
 
       it "success: with valid body" do

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -352,7 +352,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 202,
-          :parsed_body => a_hash_including(attributes)
+          :parsed_body => {}
         )
       end
 
@@ -375,7 +375,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 202,
-          :parsed_body => a_hash_including(attributes)
+          :parsed_body => {}
         )
       end
     end

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe("v1.0 - Sources") do
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   describe("/api/v1.0/sources") do


### PR DESCRIPTION
Adding the POST `/api/sources/:source_id/check_availability` action
- Action triggers an availability check on the Source[:source_id] specified
- Returns a 202 with empty {} body for now.