### PR TITLE
Add cluster id to Openshift fields

### DIFF
--- a/db/seeds/source_types.rb
+++ b/db/seeds/source_types.rb
@@ -13,6 +13,7 @@ openshift_json_schema = {
     :name   => "Token",
     :fields => [
       {:component => "text-field", :name => "authentication.authtype", :hideField => true, :initializeOnMount => true, :initialValue => "token"},
+      {:component => "text-field", :name => "source.source_ref", :label => "Cluster ID", :stepKey => 'usageCollector'},
       {:component => "text-field", :name => "authentication.password", :label => "Token", :type => "password"}
     ]
   }],


### PR DESCRIPTION
related https://github.com/RedHatInsights/sources-ui/issues/127

Cost management needs the cluster id field to be shown in the review step.

//cc @rvsia 