### PR TITLE
Add an availability check URL for applications

### DIFF
--- a/db/migrate/20191204145726_add_availability_check_url_to_application_types.rb
+++ b/db/migrate/20191204145726_add_availability_check_url_to_application_types.rb
@@ -1,0 +1,5 @@
+class AddAvailabilityCheckUrlToApplicationTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :application_types, :availability_check_url, :string
+  end
+end


### PR DESCRIPTION
Add a URL for applications to register to allow for per-app availability
checking of sources.

This will be invoked by the normal availabililty check (scheduled and
on-demand) for all enabled applications for a source.

Applications will receive a POST action to check the availability of all
related resources for the specified source by ID, then the application
will update the source via the API to set the availability_status.