### PR TITLE
Add an internal API to update the application_types

### DIFF
--- a/app/controllers/internal/v1/application_types_controller.rb
+++ b/app/controllers/internal/v1/application_types_controller.rb
@@ -1,0 +1,11 @@
+module Internal
+  module V1
+    class ApplicationTypesController < ::ApplicationController
+      def update
+        record = model.update(params.require(:id), params_for_update)
+        raise_event("#{model}.update", record.as_json)
+        head :no_content
+      end
+    end
+  end
+end

--- a/app/controllers/internal/v1x0.rb
+++ b/app/controllers/internal/v1x0.rb
@@ -1,6 +1,7 @@
 module Internal
   module V1x0
     class AuthenticationsController < Internal::V1::AuthenticationsController; end
+    class ApplicationTypesController < Internal::V1::ApplicationTypesController; end
     class TenantsController < Internal::V1::TenantsController; end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,8 +40,9 @@ Rails.application.routes.draw do
     routing_helper.redirect_major_version("v1.0", "internal", :via => [:get])
 
     namespace :v1x0, :path => "v1.0" do
-      resources :authentications, :only => [:show]
-      resources :tenants,         :only => [:index, :show]
+      resources :application_types, :only => [:update]
+      resources :authentications,   :only => [:show]
+      resources :tenants,           :only => [:index, :show]
     end
   end
 end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -85,6 +85,45 @@
             }
           }
         }
+      },
+      "patch": {
+        "summary": "Update an existing ApplicationType",
+        "operationId": "updateApplicationType",
+        "description": "Updates a ApplicationType object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationType"
+              }
+            }
+          },
+          "description": "ApplicationType attributes to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Updated, no content"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/application_types/{id}/sources": {


### PR DESCRIPTION
Allow applications to update their application_type record over the
internal API