### PR TITLE
[WIP] Updated sources-api to leverage environment for availability_check_urls

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -42,7 +42,8 @@ module Api
 
       def check_application_availability(source)
         source.application_types.each do |app_type|
-          url = app_type.availability_check_url
+          app_env_prefix = app_type.name.split('/').last.upcase.tr('-', '_')
+          url = ENV["#{app_env_prefix}_AVAILABILITY_CHECK_URL"]
           next if url.blank?
 
           begin

--- a/db/migrate/20191213165335_remove_availability_check_url_from_application_types.rb
+++ b/db/migrate/20191213165335_remove_availability_check_url_from_application_types.rb
@@ -1,0 +1,5 @@
+class RemoveAvailabilityCheckUrlFromApplicationTypes < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :application_types, :availability_check_url, :string
+  end
+end

--- a/public/doc/openapi-3-v1.0.0.json
+++ b/public/doc/openapi-3-v1.0.0.json
@@ -1304,9 +1304,6 @@
       "ApplicationType": {
         "type": "object",
         "properties": {
-          "availability_check_url": {
-            "type": "string"
-          },
           "created_at": {
             "format": "date-time",
             "readOnly": true,


### PR DESCRIPTION
Updated sources-api so that we don't store the availability_check_url in the application type, but leverage it from the environment.

this way applications can define their own for the different staged environments without needing to update the database.