### PR TITLE
Ensure that only one endpoint is "default"

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -5,6 +5,7 @@ class Endpoint < ApplicationRecord
   has_many   :authentications, :as => :resource, :dependent => :destroy
 
   validates :role, :uniqueness => { :scope => :source_id }
+  validates :default, :uniqueness => {:scope => :source_id}, :if => :default
 
   attribute :availability_status, :string
   validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -6,4 +6,15 @@ describe Endpoint do
       expect(endpoint.base_url_path).to eq("https://www.example.com:1234")
     end
   end
+
+  describe "#default" do
+    let(:source_type) { SourceType.find_or_create_by!(:name => "amazon", :product_name => "Amazon Web Services", :vendor => "Amazon") }
+    let(:tenant) { Tenant.create!(:external_tenant => SecureRandom.uuid) }
+    let(:source) { Source.create!(:name => "my-source", :tenant => tenant, :source_type => source_type) }
+
+    it "allows only one default endpoint" do
+      described_class.create!(:role => "first", :default => true, :tenant => tenant, :source => source)
+      expect { described_class.create!(:role => "second", :default => true, :tenant => tenant, :source => source) }.to raise_exception
+    end
+  end
 end


### PR DESCRIPTION
Previously it was possible to have multiple "default" endpoints.  This
can cause issues when code assumes that only one endpoint is default.