### PR TITLE
Exposing the sort_by parameter for queries.

### DIFF
--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -4,11 +4,12 @@ module Api
       module IndexMixin
         def index
           raise_unless_primary_instance_exists
-          render json: Insights::API::Common::PaginatedResponse.new(
-            base_query: scoped(filtered.where(params_for_list)),
-            request: request,
-            limit: pagination_limit,
-            offset: pagination_offset
+          render :json => Insights::API::Common::PaginatedResponse.new(
+            :base_query => scoped(filtered.where(params_for_list)),
+            :request    => request,
+            :limit      => pagination_limit,
+            :offset     => pagination_offset,
+            :sort_by    => query_sort_by
           ).response
         end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,11 +82,11 @@ class ApplicationController < ActionController::API
 
   def safe_params_for_list
     # :limit & :offset can be passed in for pagination purposes, but shouldn't show up as params for filtering purposes
-    @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params, :filter => {})
+    @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params, :filter => {}, :sort_by => [])
   end
 
   def permitted_params
-    api_doc_definition.all_attributes + [:limit, :offset] + [subcollection_foreign_key]
+    api_doc_definition.all_attributes + [:limit, :offset, :sort_by] + [subcollection_foreign_key]
   end
 
   def subcollection_foreign_key
@@ -155,6 +155,10 @@ class ApplicationController < ActionController::API
 
   def pagination_offset
     safe_params_for_list[:offset]
+  end
+
+  def query_sort_by
+    safe_params_for_list[:sort_by]
   end
 
   def params_for_update

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -53,6 +53,27 @@ RSpec.describe("Sources Filtering") do
     it("version:not_nil")                          { expect_success("filter[version][not_nil]", source_1, source_2, source_4) }
   end
 
+  context "sorted results via sort_by" do
+    before do
+      Source.create!(:name => "sort_by_source_a", :source_type => source_type, :tenant => tenant)
+      Source.create!(:name => "sort_by_source_b", :source_type => source_type, :tenant => tenant)
+    end
+
+    it "available for sources with default order" do
+      get("/api/v1.0/sources?filter[name][starts_with]=sort_by_source&sort_by=name", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |source| source["name"] }).to eq(%w[sort_by_source_a sort_by_source_b])
+    end
+
+    it "available for sources with desc order" do
+      get("/api/v1.0/sources?filter[name][starts_with]=sort_by_source&sort_by=name:desc", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |source| source["name"] }).to eq(%w[sort_by_source_b sort_by_source_a])
+    end
+  end
+
   context "error cases" do
     let!(:source_1) { create_source("aaa", :version => "1") }
     let!(:source_2) { create_source("bbb") }


### PR DESCRIPTION
Enabling the sort_by parameter, was only exposed via GraphQL for all, for rest, only the common dummy app in common had it exposed.

Added a small spec to verify it is now exposed here, the comprehensive tests for sort_by is in common.

Fixes: TPINVTRY-801