### PR TITLE
Only allow org-admin to be able to use the sources-api.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::API
     Insights::API::Common::Request.with_request(request) do |current|
       begin
         if Tenant.tenancy_enabled? && Insights::API::Common::RBAC::Access.enabled?
-          raise RbacError unless current.user.org_admin?
+          raise RbacError unless current.user.org_admin? || [:get, :head, :options].include?(request.request_method_symbol)
         end
         if Tenant.tenancy_enabled? && current.required_auth?
           raise Insights::API::Common::EntitlementError unless request_is_entitled?(current.entitlement)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe ApplicationController, :type => :request do
       headers = {
         "CONTENT_TYPE"  => "application/json",
         "x-rh-identity" => Base64.encode64(
-          {'identity' => { 'account_number' => external_tenant}, :entitlements => entitlements}.to_json
+          {'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}, :entitlements => entitlements}.to_json
         )
       }
 
@@ -100,7 +100,7 @@ RSpec.describe ApplicationController, :type => :request do
       headers = {
         "CONTENT_TYPE"  => "application/json",
         "x-rh-identity" => Base64.encode64(
-          {'identity' => { 'account_number' => external_tenant}, :entitlements => entitlements}.to_json
+          {'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}, :entitlements => entitlements}.to_json
         )
       }
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe("v1.0 - Sources") do
         post(collection_path, :params => attributes.to_json, :headers => headers)
 
         second_tenant = rand(1000).to_s
-        second_identity = {"x-rh-identity" => Base64.encode64({"identity" => {"account_number" => second_tenant}}.to_json)}
+        second_identity = {"x-rh-identity" => Base64.encode64({"identity" => {"account_number" => second_tenant, "user" => { "is_org_admin" => true }}}.to_json)}
         post(collection_path, :params => attributes.to_json, :headers => headers.merge(second_identity))
 
         expect(response).to have_attributes(

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -7,8 +7,8 @@ module Spec
         let!(:tenant)           { Tenant.create!(:name => "default", :external_tenant => external_tenant) }
         let!(:external_tenant)  { rand(1000).to_s }
         let!(:unknown_tenant)   { rand(1000).to_s }
-        let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant}}.to_json) }
-        let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => unknown_tenant}}.to_json) }
+        let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}}.to_json) }
+        let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => unknown_tenant,  'user' => { 'is_org_admin' => true }}}.to_json) }
 
         let!(:entitlements) do
           {
@@ -19,7 +19,7 @@ module Spec
 
         let!(:identity_with_entitlements) do
           Base64.encode64(
-            {'identity' => { 'account_number' => external_tenant}, :entitlements => entitlements}.to_json
+            {'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}, :entitlements => entitlements}.to_json
           )
         end
       end


### PR DESCRIPTION
Only allow org-admin to be able to use the sources-api - All others get a 403.

For development environments, the following can be set to skip the check:

```
BYPASS_RBAC=true
```
