### PR TITLE
Add missing required validators to Openshift and Ansible Tower

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -176,6 +176,9 @@ openshift:
         :name: authentication.password
         :label: Token
         :type: password
+        :isRequired: true
+        :validate:
+        - :type: required-validator
     :endpoint:
       :title: Configure OpenShift endpoint
       :fields:

--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -72,10 +72,16 @@ ansible-tower:
       - :component: text-field
         :name: authentication.username
         :label: User name
+        :isRequired: true
+        :validate:
+        - :type: required-validator
       - :component: text-field
         :name: authentication.password
         :label: Secret Key
         :type: password
+        :isRequired: true
+        :validate:
+        - :type: required-validator
     :endpoint:
       :title: Configure Ansible Tower endpoint
       :fields:


### PR DESCRIPTION
fixes TPINVTRY-711

Token (password) is required for Openshift

User name (username) and Secret key (password) are required for Ansible Tower