### PR TITLE
Drop to a single puma thread and log before and after publishing to kafka

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -21,9 +21,11 @@ module Api
 
       def check_availability
         source = Source.find(params[:source_id])
+        topic  = "platform.topological-inventory.operations-#{source.source_type.name}"
 
+        logger.debug("publishing message to #{topic}...")
         Sources::Api::Messaging.client.publish_topic(
-          :service => "platform.topological-inventory.operations-#{source.source_type.name}",
+          :service => topic,
           :event   => "Source.availability_check",
           :payload => {
             :params => {
@@ -32,6 +34,7 @@ module Api
             }
           }
         )
+        logger.debug("publishing message to #{topic}...Complete")
 
         check_application_availability(source)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,7 +72,9 @@ class ApplicationController < ActionController::API
 
   def raise_event(event, payload)
     headers = Insights::API::Common::Request.current_forwardable
+    logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
     Sources::Api::Events.raise_event(event, payload, headers)
+    logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
   end
 
   def params_for_create

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 1 }.to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.


### PR DESCRIPTION
To help investigate lockups in the sources-api drop to a single puma thread and log before and after publishing to kafka topics including the name of the topic.
This should help us identify if the source of the issue is concurrency related or using one kafka client to publish to multiple topics.