### PR TITLE
Fix Azure icon typo

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -114,7 +114,7 @@ ansible-tower:
 azure:
   :product_name: Microsoft Azure
   :vendor: Azure
-  :icon_url: "/apps/chrome/assets/images/partners-icons/miscrosoft-azure.svg"
+  :icon_url: "/apps/chrome/assets/images/partners-icons/microsoft-azure.svg"
   :schema:
     :authentication:
     - :type: tenant_id_client_id_client_secret


### PR DESCRIPTION
Typo in chrome has been fixed (https://github.com/RedHatInsights/insights-chrome/pull/547), so here we go