### PR TITLE
Cache kafka connection per thread

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 1 }.to_i
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -12,18 +12,7 @@ module Sources
 
         publish_opts[:headers] = headers if headers
 
-        messaging_client.publish_topic(publish_opts)
-      end
-
-      private_class_method def self.messaging_client
-        require "manageiq-messaging"
-
-        @messaging_client ||= ManageIQ::Messaging::Client.open(
-          :protocol => :Kafka,
-          :host     => ENV["QUEUE_HOST"] || "localhost",
-          :port     => ENV["QUEUE_PORT"] || "9092",
-          :encoding => "json"
-        )
+        Messaging.client.publish_topic(publish_opts)
       end
     end
   end

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -2,14 +2,16 @@ module Sources
   module Api
     module Messaging
       def self.client
-        require "manageiq-messaging"
+        Thread.current[:messaging_client] ||= begin
+          require "manageiq-messaging"
 
-        @client ||= ManageIQ::Messaging::Client.open(
-          :protocol => :Kafka,
-          :host     => ENV["QUEUE_HOST"] || "localhost",
-          :port     => ENV["QUEUE_PORT"] || "9092",
-          :encoding => "json"
-        )
+          ManageIQ::Messaging::Client.open(
+            :protocol => :Kafka,
+            :host     => ENV["QUEUE_HOST"] || "localhost",
+            :port     => ENV["QUEUE_PORT"] || "9092",
+            :encoding => "json"
+          )
+        end
       end
     end
   end

--- a/spec/controllers/api/v1x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v1x0/endpoints_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1x0::EndpointsController, :type => :request do
 
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   it "post /endpoints creates an Endpoint" do

--- a/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::DestroyMixin do
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
     end
 
     it "Primary Collection: delete /sources/:id destroys a Source" do

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::UpdateMixin do
 
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
     end
 
     it "patch /sources/:id updates a Source" do

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v1.0 - Authentications") do
   let(:client) { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe("v1.0 - SourceTypes") do
       let(:client) { instance_double("ManageIQ::Messaging::Client") }
       before do
         allow(client).to receive(:publish_topic)
-        allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+        allow(Sources::Api::Messaging).to receive(:client).and_return(client)
       end
 
       it "success: with valid body" do

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe("v1.0 - Sources") do
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   describe("/api/v1.0/sources") do


### PR DESCRIPTION
Cache the kafka connection per thread not globally and set the puma
threads back to 5