### PR TITLE
Add logging to the seeding step

### DIFF
--- a/app/models/concerns/seeding_concern.rb
+++ b/app/models/concerns/seeding_concern.rb
@@ -5,6 +5,7 @@ module SeedingConcern
     cattr_accessor :seed_key
 
     def seed
+      logger.info("Seeding #{name}...")
       seeds = YAML.load_file(Rails.root.join("db/seeds/#{table_name}.yml"))
 
       transaction do
@@ -12,14 +13,18 @@ module SeedingConcern
 
         seeds.each do |key, attributes|
           if (r = records.delete(key))
+            logger.info("Updating #{key}")
             r.update!(attributes)
           else
+            logger.info("Creating #{key}")
             create!(attributes.merge(seed_key => key))
           end
         end
 
+        records.each_key { |key| logger.info("Deleting #{key}") }
         records.values.map(&:destroy)
       end
+      logger.info("Seeding #{name}...Complete")
     end
   end
 end


### PR DESCRIPTION
To help improve debugging of missing seeded records we can log
creates/updates/deletes for the seed classes.