### PR TITLE
Don't share a kafka connection

### DIFF
--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -12,7 +12,18 @@ module Sources
 
         publish_opts[:headers] = headers if headers
 
-        Messaging.client.publish_topic(publish_opts)
+        messaging_client.publish_topic(publish_opts)
+      end
+
+      private_class_method def self.messaging_client
+        require "manageiq-messaging"
+
+        Thread.current[:event_messaging_client] ||= ManageIQ::Messaging::Client.open(
+          :protocol => :Kafka,
+          :host     => ENV["QUEUE_HOST"] || "localhost",
+          :port     => ENV["QUEUE_PORT"] || "9092",
+          :encoding => "json"
+        )
       end
     end
   end

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -2,16 +2,14 @@ module Sources
   module Api
     module Messaging
       def self.client
-        Thread.current[:messaging_client] ||= begin
-          require "manageiq-messaging"
+        require "manageiq-messaging"
 
-          ManageIQ::Messaging::Client.open(
-            :protocol => :Kafka,
-            :host     => ENV["QUEUE_HOST"] || "localhost",
-            :port     => ENV["QUEUE_PORT"] || "9092",
-            :encoding => "json"
-          )
-        end
+        Thread.current[:messaging_client] ||= ManageIQ::Messaging::Client.open(
+          :protocol => :Kafka,
+          :host     => ENV["QUEUE_HOST"] || "localhost",
+          :port     => ENV["QUEUE_PORT"] || "9092",
+          :encoding => "json"
+        )
       end
     end
   end

--- a/spec/controllers/api/v1x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v1x0/endpoints_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1x0::EndpointsController, :type => :request do
 
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
   end
 
   it "post /endpoints creates an Endpoint" do

--- a/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::DestroyMixin do
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
     end
 
     it "Primary Collection: delete /sources/:id destroys a Source" do

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::UpdateMixin do
 
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
     end
 
     it "patch /sources/:id updates a Source" do

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v1.0 - Authentications") do
   let(:client) { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
   end
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe("v1.0 - SourceTypes") do
       let(:client) { instance_double("ManageIQ::Messaging::Client") }
       before do
         allow(client).to receive(:publish_topic)
-        allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+        allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
       end
 
       it "success: with valid body" do

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe("v1.0 - Sources") do
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
   end
 
   describe("/api/v1.0/sources") do


### PR DESCRIPTION
It seems that sharing a common kafka connection for posting to different
topics causes issues with being unable to assign partitions to messages
leading to Kafka::DeliverFailed errors