### PR TITLE
Check list of available topics before publishing a message

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -39,7 +39,7 @@ module Api
 
           logger.debug("publishing message to #{topic}...Complete")
         else
-          logger.debug("not publishing message to non-existing topic: #{topic}")
+          logger.error("not publishing message to non-existing topic: #{topic}")
         end
 
         check_application_availability(source)

--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -23,19 +23,24 @@ module Api
         source = Source.find(params[:source_id])
         topic  = "platform.topological-inventory.operations-#{source.source_type.name}"
 
-        logger.debug("publishing message to #{topic}...")
-        messaging_client = Sources::Api::Messaging.client(topic)
-        messaging_client.publish_topic(
-          :service => topic,
-          :event   => "Source.availability_check",
-          :payload => {
-            :params => {
-              :source_id       => source.id.to_s,
-              :external_tenant => source.tenant.external_tenant
+        if Sources::Api::Messaging.topics.include?(topic)
+          logger.debug("publishing message to #{topic}...")
+
+          Sources::Api::Messaging.client.publish_topic(
+            :service => topic,
+            :event   => "Source.availability_check",
+            :payload => {
+              :params => {
+                :source_id       => source.id.to_s,
+                :external_tenant => source.tenant.external_tenant
+              }
             }
-          }
-        )
-        logger.debug("publishing message to #{topic}...Complete")
+          )
+
+          logger.debug("publishing message to #{topic}...Complete")
+        else
+          logger.debug("not publishing message to non-existing topic: #{topic}")
+        end
 
         check_application_availability(source)
 

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -12,18 +12,7 @@ module Sources
 
         publish_opts[:headers] = headers if headers
 
-        messaging_client.publish_topic(publish_opts)
-      end
-
-      private_class_method def self.messaging_client
-        require "manageiq-messaging"
-
-        @messaging_client ||= ManageIQ::Messaging::Client.open(
-          :protocol => :Kafka,
-          :host     => ENV["QUEUE_HOST"] || "localhost",
-          :port     => ENV["QUEUE_PORT"] || "9092",
-          :encoding => "json"
-        )
+        Messaging.client.publish_topic(publish_opts)
       end
     end
   end

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -1,3 +1,5 @@
+require "more_core_extensions/core_ext/module/cache_with_timeout"
+
 module Sources
   module Api
     module Messaging
@@ -14,7 +16,7 @@ module Sources
         end
       end
 
-      def self.topics
+      cache_with_timeout(:topics) do
         # TODO add an interface to ManageIQ::Messaging::Client to get a topic list
         client.send(:kafka_client)&.topics || []
       end

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -1,16 +1,22 @@
 module Sources
   module Api
     module Messaging
-      def self.client(topic)
+      def self.client
         require "manageiq-messaging"
 
-        @client ||= {}
-        @client[topic] ||= ManageIQ::Messaging::Client.open(
-          :protocol => :Kafka,
-          :host     => ENV["QUEUE_HOST"] || "localhost",
-          :port     => ENV["QUEUE_PORT"] || "9092",
-          :encoding => "json"
-        )
+        Thread.current[:messaging_client] ||= begin
+          ManageIQ::Messaging::Client.open(
+            :protocol => :Kafka,
+            :host     => ENV["QUEUE_HOST"] || "localhost",
+            :port     => ENV["QUEUE_PORT"] || "9092",
+            :encoding => "json"
+          )
+        end
+      end
+
+      def self.topics
+        # TODO add an interface to ManageIQ::Messaging::Client to get a topic list
+        client.send(:kafka_client)&.topics || []
       end
     end
   end

--- a/spec/controllers/api/v1x0/endpoints_controller_spec.rb
+++ b/spec/controllers/api/v1x0/endpoints_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Api::V1x0::EndpointsController, :type => :request do
 
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   it "post /endpoints creates an Endpoint" do

--- a/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::DestroyMixin do
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
     end
 
     it "Primary Collection: delete /sources/:id destroys a Source" do

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -10,7 +10,7 @@ describe Api::V1::Mixins::UpdateMixin do
 
     before do
       allow(client).to receive(:publish_topic)
-      allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
     end
 
     it "patch /sources/:id updates a Source" do

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v1.0 - Authentications") do
   let(:client) { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
-    allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
   end
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe("v1.0 - SourceTypes") do
       let(:client) { instance_double("ManageIQ::Messaging::Client") }
       before do
         allow(client).to receive(:publish_topic)
-        allow(Sources::Api::Events).to receive(:messaging_client).and_return(client)
+        allow(Sources::Api::Messaging).to receive(:client).and_return(client)
       end
 
       it "success: with valid body" do

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -327,10 +327,12 @@ RSpec.describe("v1.0 - Sources") do
 
       allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
 
-      allow(kafka_client).to receive(:topics).and_return([
-        "platform.topological-inventory.operations-amazon",
-        "platform.topological-inventory.operations-openshift",
-      ])
+      allow(kafka_client).to receive(:topics).and_return(
+        [
+          "platform.topological-inventory.operations-amazon",
+          "platform.topological-inventory.operations-openshift",
+        ]
+      )
     end
 
     context "post" do
@@ -391,7 +393,7 @@ RSpec.describe("v1.0 - Sources") do
 
       it "success: with a source-type that topology doesn't support" do
         source_type = SourceType.create!(:name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
-        attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
+        attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = Source.create!(attributes.merge("tenant" => tenant))
 
         expect(messaging_client).not_to receive(:publish_topic)

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -313,6 +313,7 @@ RSpec.describe("v1.0 - Sources") do
 
   describe("/api/v1.0/sources/:id/check_availability") do
     let(:messaging_client)  { double("Sources::Api::Messaging") }
+    let(:kafka_client)      { double("Kafka::Client") }
     let(:openshift_topic)   { "platform.topological-inventory.operations-openshift" }
     let(:amazon_topic)      { "platform.topological-inventory.operations-amazon" }
 
@@ -322,14 +323,14 @@ RSpec.describe("v1.0 - Sources") do
 
     before do
       allow(messaging_client).to receive(:publish_topic)
+      allow(messaging_client).to receive(:kafka_client).and_return(kafka_client)
+
       allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
 
-      allow(Sources::Api::Messaging).to receive(:topics).and_return([
+      allow(kafka_client).to receive(:topics).and_return([
         "platform.topological-inventory.operations-amazon",
         "platform.topological-inventory.operations-openshift",
-      ]
-
-      )
+      ])
     end
 
     context "post" do


### PR DESCRIPTION
To prevent messages destined for non-existant topics blocking other valid messages from being delivered, check the list of topics (cached) before publishing a message.