### PR TITLE
Bump puma threads back up to 5

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 1 }.to_i
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests, default is 3000.


### PR DESCRIPTION
Now that we have figured out what was blocking the kafka publish we
should be able to bump the puma threads back up to 5.