### PR TITLE
Allow read-only access for graphql

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -21,6 +21,13 @@ module Api
         )
         render :json => result
       end
+
+      private
+
+      # RBAC readonly access is allowed for graphql's POST
+      def request_is_readonly
+        true
+      end
     end
   end
 end


### PR DESCRIPTION
although grapqhl request is POST, it's actually like GET so RBAC read-only access should be allowed