### PR TITLE
Add a Cloud Meter application and Auth Type

### DIFF
--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -22,6 +22,14 @@
     - tenant_id_client_id_client_secret
     openshift:
     - token
+"/insights/platform/cloud-meter":
+  :display_name: Cloud Meter
+  :dependent_applications: []
+  :supported_source_types:
+  - amazon
+  :supported_authentication_types:
+    amazon:
+    - cloud-meter-arn
 "/insights/platform/topological-inventory":
   :display_name: Topological Inventory
   :dependent_applications: []

--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -46,6 +46,25 @@ amazon:
           :pattern: "^arn:aws:.*"
         - :type: min-length-validator
           :threshold: 10
+    - :type: cloud-meter-arn
+      :name: Cloud Meter ARN
+      :fields:
+      - :component: text-field
+        :name: authentication.authtype
+        :hideField: true
+        :initializeOnMount: true
+        :initialValue: cloud-meter-arn
+      - :name: authentication.password
+        :stepKey: arn
+        :component: text-field
+        :label: ARN
+        :isRequired: true
+        :validate:
+        - :type: required-validator
+        - :type: pattern-validator
+          :pattern: "^arn:aws:.*"
+        - :type: min-length-validator
+          :threshold: 10
     :endpoint:
       :hidden: true
       :fields:


### PR DESCRIPTION
This adds an application_type for CloudMeter and also adds a new
cloud-meter-arn auth type.  Since the ARN that cloud meter needs is
different from the one that cost management needs we need a different
auth-type for now.

Fixes https://github.com/RedHatInsights/sources-api/issues/172