### PR TITLE
Remove stepKey from Cloud Meter ARN auth

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -55,7 +55,6 @@ amazon:
         :initializeOnMount: true
         :initialValue: cloud-meter-arn
       - :name: authentication.password
-        :stepKey: arn
         :component: text-field
         :label: ARN
         :isRequired: true


### PR DESCRIPTION
Sorry, my fault, I haven't noticed this during the review. :(

`stepKey` is only used when the authtype has custom UI position. And right now, Cloud Meter ARN is just a plain input.