### PR TITLE
The central.maven.org repo doesn't exist anymore

### DIFF
--- a/lib/tasks/client_generate.rake
+++ b/lib/tasks/client_generate.rake
@@ -7,7 +7,7 @@ class ClientGenerator
   require 'uri'
 
   VERSION = "4.2.1".freeze
-  SOURCE_URL = "http://central.maven.org/maven2/org/openapitools/openapi-generator-cli".freeze
+  SOURCE_URL = "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli".freeze
 
   def msg(message)
     STDOUT.puts(message)
@@ -43,7 +43,7 @@ class ClientGenerator
   end
 
   def openapi_file
-    @openapi_file ||= Pathname.new(Rails.root.join("public/doc/openapi-3-v#{api_version}.0.json")).to_s
+    @openapi_file ||= Pathname.new(Rails.root.join("public/doc/openapi-3-v#{api_version}.json")).to_s
   end
 
   def openapi_yaml_file


### PR DESCRIPTION
Point the client:generate rake task at the correct maven repository.

OpenAPITools updated their download link as well: https://github.com/OpenAPITools/openapi-generator-cli/commit/b4826accb739258a6732f157e3a1a54346522b21