### PR TITLE
Don't return the 'tenant' attribute

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -1,32 +1,5 @@
 require 'insights/api/common/open_api/generator'
 class OpenapiGenerator < Insights::API::Common::OpenApi::Generator
-  def generator_blacklist_allowed_attributes
-    @generator_blacklist_allowed_attributes ||= {
-      :tenant_id => ['Authentication', 'Application', 'Endpoint', 'Source'].to_set.freeze
-    }
-  end
-
-  def generator_blacklist_substitute_attributes
-    @generator_blacklist_substitute_attributes ||= {
-      :tenant_id => ["tenant", { "type" => "string", "readOnly" => true }].freeze
-    }
-  end
-
-  def schemas
-    @schemas ||= begin
-      super.merge(
-        "Tenant" => {
-          "type"       => "object",
-          "properties" => {
-            "name"            => {"type" => "string", "readOnly" => true, "example" => "Sample Tenant"},
-            "description"     => {"type" => "string", "readOnly" => true, "example" => "Description of the Tenant"},
-            "external_tenant" => {"type" => "string", "readOnly" => true, "example" => "External tenant identifier"}
-          }
-        }
-      )
-    end
-  end
-
   def handle_custom_route_action(route_action, verb, primary_collection)
     case [primary_collection, verb, route_action]
     when ["Source", "post", "CheckAvailability"]

--- a/public/doc/openapi-3-v2.0.json
+++ b/public/doc/openapi-3-v2.0.json
@@ -1261,10 +1261,6 @@
           "source_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "tenant": {
-            "type": "string",
-            "readOnly": true
-          },
           "updated_at": {
             "format": "date-time",
             "readOnly": true,
@@ -1393,10 +1389,6 @@
           "status_details": {
             "type": "string"
           },
-          "tenant": {
-            "type": "string",
-            "readOnly": true
-          },
           "username": {
             "example": "user@example.com",
             "type": "string"
@@ -1506,10 +1498,6 @@
           },
           "source_id": {
             "$ref": "#/components/schemas/ID"
-          },
-          "tenant": {
-            "type": "string",
-            "readOnly": true
           },
           "updated_at": {
             "format": "date-time",
@@ -1640,10 +1628,6 @@
           "source_type_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "tenant": {
-            "type": "string",
-            "readOnly": true
-          },
           "uid": {
             "readOnly": true,
             "title": "Unique ID of the inventory source installation",
@@ -1731,26 +1715,6 @@
             "items": {
               "$ref": "#/components/schemas/Source"
             }
-          }
-        }
-      },
-      "Tenant": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "readOnly": true,
-            "example": "Sample Tenant"
-          },
-          "description": {
-            "type": "string",
-            "readOnly": true,
-            "example": "Description of the Tenant"
-          },
-          "external_tenant": {
-            "type": "string",
-            "readOnly": true,
-            "example": "External tenant identifier"
           }
         }
       }

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -134,16 +134,6 @@ RSpec.describe("v2.0 - Sources") do
           :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Record not unique").to_h
         )
       end
-
-      it "ignores blacklisted params" do
-        post(collection_path, :params => attributes.merge("tenant" => "123456").to_json, :headers => headers)
-
-        expect(response).to have_attributes(
-          :status      => 201,
-          :location    => "http://www.example.com/api/v2.0/sources/#{response.parsed_body["id"]}",
-          :parsed_body => a_hash_including(attributes)
-        )
-      end
     end
   end
 
@@ -299,13 +289,13 @@ RSpec.describe("v2.0 - Sources") do
 
       it "rejects read_only attributes" do
         instance = Source.create!(attributes.merge("tenant" => tenant))
-        new_attributes = {"name" => "new name", "tenant" => "123456"}
+        new_attributes = {"name" => "new name", "created_at" => Time.now.utc}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
 
         expect(response).to have_attributes(
           :status      => 400,
-          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :tenant", "status" => 400 }]}
+          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :created_at", "status" => 400 }]}
         )
       end
     end


### PR DESCRIPTION
The tenant attribute maps to the user's identity.account_number which is only relevant internally.  Users of the API who login through 3scale will only ever be able to see a single tenant so this attribute isn't helpful and can be confusing.  Also since it isn't a proper relationship (it is the tenant.external_tenant not tenant_id) it can trip up things like filtering.  In v2.0 we should drop this attribute.

Relates to JIRA: TPINVTRY-742