### PR TITLE
Source UUID to Kafka in Check availability

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -32,6 +32,7 @@ module Api
             :payload => {
               :params => {
                 :source_id       => source.id.to_s,
+                :source_uid      => source.uid.to_s,
                 :external_tenant => source.tenant.external_tenant
               }
             }


### PR DESCRIPTION
Satellite availabiliity check needs Source UID as an argument, so passing it in Sources API will save one API request from satellite-operations