### PR TITLE
change display name "Cloud Meter" to "Subscription Watch" to better match the public-facing product name

### DIFF
--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -23,7 +23,7 @@
     openshift:
     - token
 "/insights/platform/cloud-meter":
-  :display_name: Cloud Meter
+  :display_name: Subscription Watch
   :dependent_applications: []
   :supported_source_types:
   - amazon


### PR DESCRIPTION
Since this value is displayed in the UI, we need to change it because the customer will expect to see the product name "Subscription Watch", not the sub-component name "Cloud Meter".