### PR TITLE
[WIP] Moved the SortBy parameter as ob Object definition in the schema

### DIFF
--- a/public/doc/openapi-3-v2.0.json
+++ b/public/doc/openapi-3-v2.0.json
@@ -1216,18 +1216,10 @@
         "name": "sort_by",
         "description": "The list of attribute and order to sort the result set by.",
         "required": false,
+        "style": "deepObject",
+        "explode": true,
         "schema": {
-          "oneOf": [
-            {
-              "$ref": "#/components/schemas/SortByAttribute"
-            },
-            {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/SortByAttribute"
-              }
-            }
-          ]
+          "type": "object"
         }
       }
     },
@@ -1594,11 +1586,6 @@
         "description": "ID of the resource",
         "pattern": "^\\d+$",
         "readOnly": true
-      },
-      "SortByAttribute": {
-        "type": "string",
-        "description": "Attribute with optional order to sort the result set by.",
-        "pattern": "^[a-z\\-_]+(:asc|:desc)?$"
       },
       "Source": {
         "type": "object",


### PR DESCRIPTION
Moved the SortBy parameter as ob Object definition in the schema similar to the Filter. This is to get around an issue with the OpenAPI client generator not properly dealing with the OneOf Schema syntax.

Depends on: https://github.com/RedHatInsights/insights-api-common-rails/pull/160
