### PR TITLE
Allow machine credentials to create sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem 'insights-api-common',  '~> 3.4'
+gem 'insights-api-common',  '~> 3.5'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -15,24 +15,50 @@ RSpec.describe("v2.0 - Sources") do
 
   describe("/api/v2.0/sources") do
     context "get" do
-      it "success: empty collection" do
-        get(collection_path, :headers => headers)
+      context "user credentials" do
+        it "success: empty collection" do
+          get(collection_path, :headers => headers)
 
-        expect(response).to have_attributes(
-          :status => 200,
-          :parsed_body => paginated_response(0, [])
-        )
+          expect(response).to have_attributes(
+            :status => 200,
+            :parsed_body => paginated_response(0, [])
+          )
+        end
+
+        it "success: non-empty collection" do
+          Source.create!(attributes.merge("tenant" => tenant))
+
+          get(collection_path, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status => 200,
+            :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+          )
+        end
       end
 
-      it "success: non-empty collection" do
-        Source.create!(attributes.merge("tenant" => tenant))
+      context "system credentials" do
+        let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => system_identity} }
 
-        get(collection_path, :headers => headers)
+        it "success: empty collection" do
+          get(collection_path, :headers => headers)
 
-        expect(response).to have_attributes(
-          :status => 200,
-          :parsed_body => paginated_response(1, [a_hash_including(attributes)])
-        )
+          expect(response).to have_attributes(
+            :status => 200,
+            :parsed_body => paginated_response(0, [])
+          )
+        end
+
+        it "success: non-empty collection" do
+          Source.create!(attributes.merge("tenant" => tenant))
+
+          get(collection_path, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status => 200,
+            :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+          )
+        end
       end
     end
 
@@ -133,6 +159,20 @@ RSpec.describe("v2.0 - Sources") do
           :location    => nil,
           :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Record not unique").to_h
         )
+      end
+
+      context "with system credentials" do
+        let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => system_identity} }
+
+        it "success: with valid body" do
+          post(collection_path, :params => attributes.to_json, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status => 201,
+            :location => "http://www.example.com/api/v2.0/sources/#{response.parsed_body["id"]}",
+            :parsed_body => a_hash_including(attributes)
+          )
+        end
       end
     end
   end

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -9,6 +9,7 @@ module Spec
         let!(:unknown_tenant)   { rand(1000).to_s }
         let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}}.to_json) }
         let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => unknown_tenant,  'user' => { 'is_org_admin' => true }}}.to_json) }
+        let!(:system_identity)  { Base64.encode64({'identity' => {'account_number' => external_tenant, 'system' => {'cn' => rand(1000).to_s}}}.to_json) }
 
         let!(:entitlements) do
           {


### PR DESCRIPTION
For the usecase of a satellite system auto registering itself we have to allow for machine credentials to post to sources.

Depends on: https://github.com/RedHatInsights/insights-api-common-rails/pull/162
Relates to JIRA: https://projects.engineering.redhat.com/browse/TPINVTRY-870