### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This project exposes an API for accessing objects living in the Sources Service database
 
 ## Prerequisites
-You need to install ruby >= 2.4 and run:
+You need to install ruby >= 2.5 and run:
 
 ```
 bundle install


### PR DESCRIPTION
Looks like you need ruby >=2.5
```
$ bundle install
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using bundler 2.0.1
Fetching bundler-inject 1.1.0
Installing bundler-inject 1.1.0
Installed plugin bundler-inject
Fetching gem metadata from https://rubygems.org/..........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "ruby":
  In Gemfile:
    ruby

    puma (>= 4.3.1, ~> 4.3) was resolved to 4.3.1, which depends on
      ruby (>= 2.2)

    rails (~> 5.2.2) was resolved to 5.2.4.1, which depends on
      ruby (>= 2.2.2)

    rubocop (~> 0.69.0) was resolved to 0.69.0, which depends on
      ruby (>= 2.3.0)

    sprockets (~> 4.0) was resolved to 4.0.0, which depends on
      ruby (>= 2.5.0)
$ ruby --version
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]
```