### PR TITLE
Fix bug with graphql posts with non-org-admin

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -25,7 +25,7 @@ module Api
       private
 
       # RBAC readonly access is allowed for graphql's POST
-      def request_is_readonly
+      def request_is_readonly?
         true
       end
     end

--- a/spec/requests/api/graphql_controller_spec.rb
+++ b/spec/requests/api/graphql_controller_spec.rb
@@ -20,5 +20,14 @@ RSpec.describe("v1.0 - GraphQL") do
       expect(response.status).to eq(200)
       expect(result_source_tenant(response.body)).to match_array([tenant.external_tenant])
     end
+
+    it "with non-org-admin: returns the external tenant identifier" do
+      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => non_org_admin_identity }
+
+      post("/api/v1.0/graphql", :headers => headers, :params => graphql_source_query)
+
+      expect(response.status).to eq(200)
+      expect(result_source_tenant(response.body)).to match_array([tenant.external_tenant])
+    end
   end
 end

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -10,6 +10,7 @@ module Spec
         let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}}.to_json) }
         let!(:unknown_identity) { Base64.encode64({'identity' => { 'account_number' => unknown_tenant,  'user' => { 'is_org_admin' => true }}}.to_json) }
         let!(:system_identity)  { Base64.encode64({'identity' => {'account_number' => external_tenant, 'system' => {'cn' => rand(1000).to_s}}}.to_json) }
+        let!(:non_org_admin_identity) { Base64.encode64({'identity' => {'account_number' => external_tenant, 'user' => {'is_org_admin' => false}}}.to_json) }
 
         let!(:entitlements) do
           {


### PR DESCRIPTION
Fix a bug introduced by renaming request_is_readonly to request_is_readonly? (since it is a boolean method) [here](https://github.com/RedHatInsights/sources-api/pull/190/files#diff-55c5b7aecfb519d0e4880eaf2788eb6eL68) but this broke the graphql controller which overrides this to allow for posts to be treated as readonly.

Also add a spec test to cover this case.