### PR TITLE
Remove Receptor ID field from ansible Tower

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -123,12 +123,6 @@ ansible-tower:
         :condition:
           :when: endpoint.verify_ssl
           :is: true
-      - :component: switch-field
-        :name: platform_receptor
-        :label: Use Platform Receptor and PKI (?)
-      - :component: text-field
-        :name: endpoint.receptor_node
-        :label: Receptor ID
 azure:
   :product_name: Microsoft Azure
   :vendor: Azure


### PR DESCRIPTION
TPINVTRY-877

Receptor ID won't be supported in GA