### PR TITLE
Send the source.source_ref for availability check

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -33,6 +33,7 @@ module Api
               :params => {
                 :source_id       => source.id.to_s,
                 :source_uid      => source.uid.to_s,
+                :source_ref      => source.source_ref.to_s,
                 :external_tenant => source.tenant.external_tenant
               }
             }


### PR DESCRIPTION
The satellite receptor connection needs the satellite instance id which is stored in the source.source_ref attribute.