### PR TITLE
Bumping up insights-api-common to 3.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem 'insights-api-common',  '~> 3.9'
+gem 'insights-api-common',  '~> 3.10'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"


### PR DESCRIPTION
- Operators must be specified for filters that include associations.

For consistency across the board like topological-inventory.