### PR TITLE
Rename Catalog to Automation Services Catalog

### DIFF
--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -1,6 +1,6 @@
 ---
 "/insights/platform/catalog":
-  :display_name: Catalog
+  :display_name: Automation Services Catalog
   :dependent_applications:
   - "/insights/platform/topological-inventory"
   :supported_source_types:


### PR DESCRIPTION
As found on recent demo.  The application type should match the latest Catalog naming.

cc @sbuenafe-rh