### PR TITLE
Fix typo in satellite source and add migration to fix currently running instances

### DIFF
--- a/db/migrate/20200422154616_rename_satellite_initial_value.rb
+++ b/db/migrate/20200422154616_rename_satellite_initial_value.rb
@@ -1,0 +1,18 @@
+class RenameSatelliteInitialValue < ActiveRecord::Migration[5.2]
+  def up
+    rename("sattelite", "satellite")
+  end
+
+  def down
+    rename("satellite", "sattelite")
+  end
+
+  def rename(old, new)
+    SourceType.where(:name => "satellite").each do |type|
+      type.schema["endpoint"]["fields"].each do |field|
+        field["initialValue"] = new if field["initialValue"] == old
+      end
+      type.save!
+    end
+  end
+end

--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -254,7 +254,7 @@ satellite:
         :name: endpoint.role
         :hideField: true
         :initializeOnMount: true
-        :initialValue: sattelite
+        :initialValue: satellite
   :icon_url: "/apps/frontend-assets/platform-logos/satellite.svg"
 vsphere:
   :product_name: VMware vSphere


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-922

Simple PR to fix typo in the `db/seeds/source_types.yml` file as well as a migration to fix currently running instances of the Sources API.