### PR TITLE
Update source types logos according to UX

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -73,11 +73,11 @@ amazon:
         :initializeOnMount: true
         :initialValue: aws
   :vendor: Amazon
-  :icon_url: "/apps/chrome/assets/images/partners-icons/aws.svg"
+  :icon_url: "/apps/frontend-assets/partners-icons/aws-long.svg"
 ansible-tower:
   :product_name: Ansible Tower
   :vendor: Red Hat
-  :icon_url: "/apps/chrome/assets/images/platform-icons/ansible-tower.svg"
+  :icon_url: "/apps/frontend-assets/platform-logos/ansible-automation-platform.svg"
   :schema:
     :authentication:
     - :type: username_password
@@ -216,7 +216,7 @@ openshift:
           :when: endpoint.verify_ssl
           :is: true
   :vendor: Red Hat
-  :icon_url: "/apps/chrome/assets/images/platform-icons/openshift.svg"
+  :icon_url: "/apps/frontend-assets/platform-logos/openshift-container-platform.svg"
 openstack:
   :product_name: Red Hat OpenStack
   :vendor: Red Hat
@@ -255,6 +255,7 @@ satellite:
         :hideField: true
         :initializeOnMount: true
         :initialValue: sattelite
+  :icon_url: "/apps/frontend-assets/platform-logos/satellite.svg"
 vsphere:
   :product_name: VMware vSphere
   :vendor: VMware


### PR DESCRIPTION
There are new source types icons mocked by UX

![Screenshot from 2020-04-29 15-15-09](https://user-images.githubusercontent.com/32869456/80600142-3fb14e00-8a2c-11ea-9471-da0fe0c8beef.png)
![Screenshot from 2020-04-29 15-15-07](https://user-images.githubusercontent.com/32869456/80600148-417b1180-8a2c-11ea-8635-e45b024b6610.png)
![Screenshot from 2020-04-29 15-15-04](https://user-images.githubusercontent.com/32869456/80600154-42ac3e80-8a2c-11ea-8846-5a9a2963bc2f.png)
![Screenshot from 2020-04-29 15-27-41](https://user-images.githubusercontent.com/32869456/80601416-15f92680-8a2e-11ea-9d17-306efcc21630.png)

cc @syncrou 