### PR TITLE
Add 'Red Hat' to OpenShift product name, drop CloudForms

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -171,7 +171,7 @@ cloudforms:
   :product_name: Red Hat CloudForms
   :vendor: Red Hat
 openshift:
-  :product_name: OpenShift Container Platform
+  :product_name: Red Hat OpenShift Container Platform
   :schema:
     :authentication:
     - :type: token

--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -167,9 +167,6 @@ azure:
         :hideField: true
         :initializeOnMount: true
         :initialValue: azure
-cloudforms:
-  :product_name: Red Hat CloudForms
-  :vendor: Red Hat
 openshift:
   :product_name: Red Hat OpenShift Container Platform
   :schema:


### PR DESCRIPTION
OpenShift logo contains a little bit different naming than the product name:

![OpenshiftLogo](https://user-images.githubusercontent.com/32869456/80600148-417b1180-8a2c-11ea-8635-e45b024b6610.png)

vs

`OpenShift Container Platform`

@syncrou This should be probably decided by the copy, but I am not sure who is it. :D 

Mocks

https://marvelapp.com/574481j