### PR TITLE
Support for status type of string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
-gem 'insights-api-common',  '=  3.9'
+gem 'insights-api-common',  '~> 4.0'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,13 +53,13 @@ class ApplicationController < ActionController::API
           ActsAsTenant.without_tenant { yield }
         end
       rescue KeyError, Insights::API::Common::IdentityError
-        error_document = Insights::API::Common::ErrorDocument.new.add("401", 'Unauthorized')
+        error_document = Insights::API::Common::ErrorDocument.new.add('401', 'Unauthorized')
         render :json => error_document.to_h, :status => error_document.status
       rescue Insights::API::Common::EntitlementError
-        error_document = Insights::API::Common::ErrorDocument.new.add("403", 'Forbidden')
+        error_document = Insights::API::Common::ErrorDocument.new.add('403', 'Forbidden')
         render :json => error_document.to_h, :status => error_document.status
       rescue RbacError
-        error_document = Insights::API::Common::ErrorDocument.new.add("403", 'Forbidden due to Rbac')
+        error_document = Insights::API::Common::ErrorDocument.new.add('403', 'Forbidden due to Rbac')
         render :json => error_document.to_h, :status => error_document.status
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,29 +12,29 @@ class ApplicationController < ActionController::API
   around_action :with_current_request
 
   rescue_from ActiveRecord::RecordNotFound do |exception|
-    error_document = Insights::API::Common::ErrorDocument.new.add(404, "Record not found")
+    error_document = Insights::API::Common::ErrorDocument.new.add("404", "Record not found")
     render :json => error_document.to_h, :status => :not_found
   end
 
   rescue_from ActiveRecord::RecordInvalid do |exception|
     exception_msg = exception.message.split("\n").first.gsub("ActiveRecord::RecordInvalid: ", "")
-    error_document = Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - #{exception_msg}")
+    error_document = Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - #{exception_msg}")
     render :json => error_document.to_h, :status => :bad_request
   end
 
   rescue_from ActiveRecord::RecordNotUnique do |_exception|
-    error_document = Insights::API::Common::ErrorDocument.new.add(400, "Record not unique")
+    error_document = Insights::API::Common::ErrorDocument.new.add("400", "Record not unique")
     render :json => error_document.to_h, :status => :bad_request
   end
 
   rescue_from Insights::API::Common::Filter::Error do |exception|
-    error_document = Insights::API::Common::ErrorDocument.new.add(400, exception)
+    error_document = Insights::API::Common::ErrorDocument.new.add("400", exception)
     render :json => error_document.to_h, :status => error_document.status
   end
 
   rescue_from ActiveRecord::NotNullViolation do |exception|
     exception_msg = exception.message.split("\n").first.gsub("PG::NotNullViolation: ERROR:  ", "")
-    error_document = Insights::API::Common::ErrorDocument.new.add(400, "Missing parameter - #{exception_msg}")
+    error_document = Insights::API::Common::ErrorDocument.new.add("400", "Missing parameter - #{exception_msg}")
     render :json => error_document.to_h, :status => :bad_request
   end
 
@@ -53,13 +53,13 @@ class ApplicationController < ActionController::API
           ActsAsTenant.without_tenant { yield }
         end
       rescue KeyError, Insights::API::Common::IdentityError
-        error_document = Insights::API::Common::ErrorDocument.new.add(401, 'Unauthorized')
+        error_document = Insights::API::Common::ErrorDocument.new.add("401", 'Unauthorized')
         render :json => error_document.to_h, :status => error_document.status
       rescue Insights::API::Common::EntitlementError
-        error_document = Insights::API::Common::ErrorDocument.new.add(403, 'Forbidden')
+        error_document = Insights::API::Common::ErrorDocument.new.add("403", 'Forbidden')
         render :json => error_document.to_h, :status => error_document.status
       rescue RbacError
-        error_document = Insights::API::Common::ErrorDocument.new.add(403, 'Forbidden due to Rbac')
+        error_document = Insights::API::Common::ErrorDocument.new.add("403", 'Forbidden due to Rbac')
         render :json => error_document.to_h, :status => error_document.status
       end
     end

--- a/spec/requests/api/v1.0/application_types_spec.rb
+++ b/spec/requests/api/v1.0/application_types_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe("v1.0 - ApplicationTypes") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe("v1.0 - ApplicationTypes") do
 
             expect(response).to have_attributes(
               :status      => 404,
-              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
             )
           end
         end

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe("v1.0 - Authentications") do
         expect(response).to have_attributes(
                               :status => 400,
                               :location => nil,
-                              :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication/properties/extra does not define properties: amazon").to_h
+                              :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication/properties/extra does not define properties: amazon").to_h
                             )
       end
 
@@ -83,7 +83,7 @@ RSpec.describe("v1.0 - Authentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: aaa").to_h
         )
       end
 
@@ -93,7 +93,7 @@ RSpec.describe("v1.0 - Authentications") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/password expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/password expected string, but received Integer: 123").to_h
         )
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe("v1.0 - Authentications") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe("v1.0 - Authentications") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v1.0/endpoints_spec.rb
+++ b/spec/requests/api/v1.0/endpoints_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe("v1.0 - Endpoints") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
         )
       end
 
@@ -78,7 +78,7 @@ RSpec.describe("v1.0 - Endpoints") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Endpoint/properties/default expected boolean, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Endpoint/properties/default expected boolean, but received Integer: 123").to_h
         )
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe("v1.0 - Endpoints") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe("v1.0 - Endpoints") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
         )
       end
 
@@ -146,7 +146,7 @@ RSpec.describe("v1.0 - Endpoints") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe("Sources Filtering") do
 
     expect(response).to(
       have_attributes(
-        :parsed_body => { "errors" => errors.collect { |e| {"detail" => e, "status" => 400} } },
+        :parsed_body => { "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} } },
         :status      => 400,
       )
     )
@@ -85,7 +85,7 @@ RSpec.describe("Sources Filtering") do
       get("#{source_collection}?filter[bogus_attribute]=a", :headers => headers)
 
       expect(response.status).to(eq(400))
-      expect(response.parsed_body["errors"]).to(eq([{"detail" => "found unpermitted parameter: bogus_attribute", "status" => 400}]))
+      expect(response.parsed_body["errors"]).to(eq([{"detail" => "found unpermitted parameter: bogus_attribute", "status" => "400"}]))
     end
   end
 end

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe("v1.0 - SourceTypes") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/SourceType does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/SourceType does not define properties: aaa").to_h
         )
       end
 
@@ -63,7 +63,7 @@ RSpec.describe("v1.0 - SourceTypes") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/SourceType/properties/name expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/SourceType/properties/name expected string, but received Integer: 123").to_h
         )
       end
     end

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe("v1.0 - SourceTypes") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe("v1.0 - SourceTypes") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
         )
       end
 
@@ -89,7 +89,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaa").to_h
         )
       end
 
@@ -99,7 +99,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
         )
       end
 
@@ -109,7 +109,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values").to_h
         )
       end
 
@@ -119,7 +119,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::InvalidPattern: #/components/schemas/ID pattern ^\\d+$ does not match value: xxx").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::InvalidPattern: #/components/schemas/ID pattern ^\\d+$ does not match value: xxx").to_h
         )
       end
 
@@ -132,7 +132,7 @@ RSpec.describe("v1.0 - Sources") do
           :status      => 400,
           :location    => nil,
           :parsed_body => Insights::API::Common::ErrorDocument.new.add(
-            400, "Invalid parameter - Validation failed: Name has already been taken").to_h
+            "400", "Invalid parameter - Validation failed: Name has already been taken").to_h
         )
       end
 
@@ -157,7 +157,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Record not unique").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Record not unique").to_h
         )
       end
 
@@ -211,7 +211,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -239,7 +239,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors"=>[{"detail"=>"OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values", "status"=>400}]}
+          :parsed_body => {"errors"=>[{"detail"=>"OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values", "status"=>"400"}]}
         )
 
         expect(instance.reload).to have_attributes(:name => "my source")
@@ -253,7 +253,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
 
@@ -265,7 +265,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaaaa", "status" => 400}]}
+          :parsed_body => {"errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaaaa", "status" => "400"}]}
         )
       end
 
@@ -277,7 +277,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :uid", "status" => 400}]}
+          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :uid", "status" => "400"}]}
         )
       end
 
@@ -287,7 +287,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 4").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 4").to_h
         )
       end
 
@@ -297,7 +297,7 @@ RSpec.describe("v1.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Availability status is not included in the list").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Availability status is not included in the list").to_h
         )
       end
 
@@ -345,7 +345,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 400,
-          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :tenant", "status" => 400 }]}
+          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :tenant", "status" => "400" }]}
         )
       end
     end
@@ -381,7 +381,7 @@ RSpec.describe("v1.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
         )
       end
 
@@ -548,7 +548,7 @@ RSpec.describe("v1.0 - Sources") do
 
             expect(response).to have_attributes(
               :status => 404,
-              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
             )
           end
         end

--- a/spec/requests/api/v2.0/application_authentications_spec.rb
+++ b/spec/requests/api/v2.0/application_authentications_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/ApplicationAuthentication does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/ApplicationAuthentication does not define properties: aaa").to_h
         )
       end
 
@@ -73,7 +73,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 123").to_h
         )
       end
     end

--- a/spec/requests/api/v2.0/application_authentications_spec.rb
+++ b/spec/requests/api/v2.0/application_authentications_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v2.0/application_types_spec.rb
+++ b/spec/requests/api/v2.0/application_types_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe("v2.0 - ApplicationTypes") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe("v2.0 - ApplicationTypes") do
 
             expect(response).to have_attributes(
               :status      => 404,
-              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
             )
           end
         end

--- a/spec/requests/api/v2.0/applications_spec.rb
+++ b/spec/requests/api/v2.0/applications_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe("v2.0 - Applications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
         )
       end
 
@@ -70,7 +70,7 @@ RSpec.describe("v2.0 - Applications") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Application/properties/availability_status expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Application/properties/availability_status expected string, but received Integer: 123").to_h
         )
       end
     end
@@ -100,7 +100,7 @@ RSpec.describe("v2.0 - Applications") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe("v2.0 - Applications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
         )
       end
 
@@ -138,7 +138,7 @@ RSpec.describe("v2.0 - Applications") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end
@@ -170,7 +170,7 @@ RSpec.describe("v2.0 - Applications") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end

--- a/spec/requests/api/v2.0/authentications_spec.rb
+++ b/spec/requests/api/v2.0/authentications_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe("v2.0 - Authentications") do
         expect(response).to have_attributes(
                               :status => 400,
                               :location => nil,
-                              :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication/properties/extra does not define properties: amazon").to_h
+                              :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication/properties/extra does not define properties: amazon").to_h
                             )
       end
 
@@ -83,7 +83,7 @@ RSpec.describe("v2.0 - Authentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: aaa").to_h
         )
       end
 
@@ -93,7 +93,7 @@ RSpec.describe("v2.0 - Authentications") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/password expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/password expected string, but received Integer: 123").to_h
         )
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe("v2.0 - Authentications") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=> "404"}]}
         )
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe("v2.0 - Authentications") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v2.0/endpoints_spec.rb
+++ b/spec/requests/api/v2.0/endpoints_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe("v2.0 - Endpoints") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
         )
       end
 
@@ -78,7 +78,7 @@ RSpec.describe("v2.0 - Endpoints") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Endpoint/properties/default expected boolean, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Endpoint/properties/default expected boolean, but received Integer: 123").to_h
         )
       end
     end
@@ -108,7 +108,7 @@ RSpec.describe("v2.0 - Endpoints") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe("v2.0 - Endpoints") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
         )
       end
 
@@ -146,7 +146,7 @@ RSpec.describe("v2.0 - Endpoints") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v2.0/filter_spec.rb
+++ b/spec/requests/api/v2.0/filter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe("Sources Filtering") do
 
     expect(response).to(
       have_attributes(
-        :parsed_body => { "errors" => errors.collect { |e| {"detail" => e, "status" => 400} } },
+        :parsed_body => { "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} } },
         :status      => 400,
       )
     )
@@ -85,7 +85,7 @@ RSpec.describe("Sources Filtering") do
       get("#{source_collection}?filter[bogus_attribute]=a", :headers => headers)
 
       expect(response.status).to(eq(400))
-      expect(response.parsed_body["errors"]).to(eq([{"detail" => "found unpermitted parameter: bogus_attribute", "status" => 400}]))
+      expect(response.parsed_body["errors"]).to(eq([{"detail" => "found unpermitted parameter: bogus_attribute", "status" => "400"}]))
     end
   end
 end

--- a/spec/requests/api/v2.0/source_types_spec.rb
+++ b/spec/requests/api/v2.0/source_types_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe("v2.0 - SourceTypes") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe("v2.0 - SourceTypes") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
         )
       end
 
@@ -89,7 +89,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaa").to_h
         )
       end
 
@@ -99,7 +99,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
         )
       end
 
@@ -109,7 +109,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values").to_h
         )
       end
 
@@ -119,7 +119,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::InvalidPattern: #/components/schemas/ID pattern ^\\d+$ does not match value: xxx").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::InvalidPattern: #/components/schemas/ID pattern ^\\d+$ does not match value: xxx").to_h
         )
       end
 
@@ -132,7 +132,7 @@ RSpec.describe("v2.0 - Sources") do
           :status      => 400,
           :location    => nil,
           :parsed_body => Insights::API::Common::ErrorDocument.new.add(
-            400, "Invalid parameter - Validation failed: Name has already been taken").to_h
+            "400", "Invalid parameter - Validation failed: Name has already been taken").to_h
         )
       end
 
@@ -157,7 +157,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Record not unique").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Record not unique").to_h
         )
       end
 
@@ -201,7 +201,7 @@ RSpec.describe("v2.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -229,7 +229,7 @@ RSpec.describe("v2.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors"=>[{"detail"=>"OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values", "status"=>400}]}
+          :parsed_body => {"errors"=>[{"detail"=>"OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values", "status"=>"400"}]}
         )
 
         expect(instance.reload).to have_attributes(:name => "my source")
@@ -243,7 +243,7 @@ RSpec.describe("v2.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
 
@@ -255,7 +255,7 @@ RSpec.describe("v2.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaaaa", "status" => 400}]}
+          :parsed_body => {"errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaaaa", "status" => "400"}]}
         )
       end
 
@@ -267,7 +267,7 @@ RSpec.describe("v2.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :uid", "status" => 400}]}
+          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :uid", "status" => "400"}]}
         )
       end
 
@@ -277,7 +277,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 4").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 4").to_h
         )
       end
 
@@ -287,7 +287,7 @@ RSpec.describe("v2.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Availability status is not included in the list").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Availability status is not included in the list").to_h
         )
       end
 
@@ -335,7 +335,7 @@ RSpec.describe("v2.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 400,
-          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :created_at", "status" => 400 }]}
+          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :created_at", "status" => "400" }]}
         )
       end
     end
@@ -371,7 +371,7 @@ RSpec.describe("v2.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
         )
       end
 
@@ -538,7 +538,7 @@ RSpec.describe("v2.0 - Sources") do
 
             expect(response).to have_attributes(
               :status => 404,
-              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
             )
           end
         end

--- a/spec/requests/api/v3.0/application_authentications_spec.rb
+++ b/spec/requests/api/v3.0/application_authentications_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v3.0/application_authentications_spec.rb
+++ b/spec/requests/api/v3.0/application_authentications_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/ApplicationAuthentication does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/ApplicationAuthentication does not define properties: aaa").to_h
         )
       end
 
@@ -73,7 +73,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 123").to_h
         )
       end
     end

--- a/spec/requests/api/v3.0/application_types_spec.rb
+++ b/spec/requests/api/v3.0/application_types_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe("v3.0 - ApplicationTypes") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end
@@ -93,7 +93,7 @@ RSpec.describe("v3.0 - ApplicationTypes") do
 
             expect(response).to have_attributes(
               :status      => 404,
-              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
             )
           end
         end

--- a/spec/requests/api/v3.0/applications_spec.rb
+++ b/spec/requests/api/v3.0/applications_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe("v3.0 - Applications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
         )
       end
 
@@ -70,7 +70,7 @@ RSpec.describe("v3.0 - Applications") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Application/properties/availability_status expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Application/properties/availability_status expected string, but received Integer: 123").to_h
         )
       end
     end
@@ -100,7 +100,7 @@ RSpec.describe("v3.0 - Applications") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -127,7 +127,7 @@ RSpec.describe("v3.0 - Applications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
         )
       end
 
@@ -138,7 +138,7 @@ RSpec.describe("v3.0 - Applications") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end
@@ -170,7 +170,7 @@ RSpec.describe("v3.0 - Applications") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end

--- a/spec/requests/api/v3.0/authentications_spec.rb
+++ b/spec/requests/api/v3.0/authentications_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe("v3.0 - Authentications") do
         expect(response).to have_attributes(
                               :status => 400,
                               :location => nil,
-                              :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication/properties/extra does not define properties: amazon").to_h
+                              :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication/properties/extra does not define properties: amazon").to_h
                             )
       end
 
@@ -83,7 +83,7 @@ RSpec.describe("v3.0 - Authentications") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: aaa").to_h
         )
       end
 
@@ -93,7 +93,7 @@ RSpec.describe("v3.0 - Authentications") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/password expected string, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/password expected string, but received Integer: 123").to_h
         )
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe("v3.0 - Authentications") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -158,7 +158,7 @@ RSpec.describe("v3.0 - Authentications") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v3.0/endpoints_spec.rb
+++ b/spec/requests/api/v3.0/endpoints_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe("v3.0 - Endpoints") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -146,7 +146,7 @@ RSpec.describe("v3.0 - Endpoints") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
     end

--- a/spec/requests/api/v3.0/endpoints_spec.rb
+++ b/spec/requests/api/v3.0/endpoints_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe("v3.0 - Endpoints") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
         )
       end
 
@@ -78,7 +78,7 @@ RSpec.describe("v3.0 - Endpoints") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/Endpoint/properties/default expected boolean, but received Integer: 123").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Endpoint/properties/default expected boolean, but received Integer: 123").to_h
         )
       end
     end
@@ -135,7 +135,7 @@ RSpec.describe("v3.0 - Endpoints") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
         )
       end
 

--- a/spec/requests/api/v3.0/filter_spec.rb
+++ b/spec/requests/api/v3.0/filter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe("Sources Filtering") do
 
     expect(response).to(
       have_attributes(
-        :parsed_body => { "errors" => errors.collect { |e| {"detail" => e, "status" => 400} } },
+        :parsed_body => { "errors" => errors.collect { |e| {"detail" => e, "status" => "400"} } },
         :status      => 400,
       )
     )
@@ -85,7 +85,7 @@ RSpec.describe("Sources Filtering") do
       get("#{source_collection}?filter[bogus_attribute]=a", :headers => headers)
 
       expect(response.status).to(eq(400))
-      expect(response.parsed_body["errors"]).to(eq([{"detail" => "found unpermitted parameter: bogus_attribute", "status" => 400}]))
+      expect(response.parsed_body["errors"]).to(eq([{"detail" => "found unpermitted parameter: bogus_attribute", "status" => "400"}]))
     end
   end
 end

--- a/spec/requests/api/v3.0/source_types_spec.rb
+++ b/spec/requests/api/v3.0/source_types_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe("v3.0 - SourceTypes") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe("v3.0 - SourceTypes") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
         )
       end
 
@@ -89,7 +89,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status => 400,
           :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaa").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaa").to_h
         )
       end
 
@@ -99,7 +99,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Name can't be blank").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
         )
       end
 
@@ -109,7 +109,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values").to_h
         )
       end
 
@@ -119,7 +119,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::InvalidPattern: #/components/schemas/ID pattern ^\\d+$ does not match value: xxx").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::InvalidPattern: #/components/schemas/ID pattern ^\\d+$ does not match value: xxx").to_h
         )
       end
 
@@ -132,7 +132,7 @@ RSpec.describe("v3.0 - Sources") do
           :status      => 400,
           :location    => nil,
           :parsed_body => Insights::API::Common::ErrorDocument.new.add(
-            400, "Invalid parameter - Validation failed: Name has already been taken").to_h
+            "400", "Invalid parameter - Validation failed: Name has already been taken").to_h
         )
       end
 
@@ -157,7 +157,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Record not unique").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Record not unique").to_h
         )
       end
 
@@ -201,7 +201,7 @@ RSpec.describe("v3.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
     end
@@ -229,7 +229,7 @@ RSpec.describe("v3.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors"=>[{"detail"=>"OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values", "status"=>400}]}
+          :parsed_body => {"errors"=>[{"detail"=>"OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values", "status"=>"400"}]}
         )
 
         expect(instance.reload).to have_attributes(:name => "my source")
@@ -243,7 +243,7 @@ RSpec.describe("v3.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 404,
-          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+          :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
         )
       end
 
@@ -255,7 +255,7 @@ RSpec.describe("v3.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaaaa", "status" => 400}]}
+          :parsed_body => {"errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaaaa", "status" => "400"}]}
         )
       end
 
@@ -267,7 +267,7 @@ RSpec.describe("v3.0 - Sources") do
 
         expect(response).to have_attributes(
           :status => 400,
-          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :uid", "status" => 400}]}
+          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :uid", "status" => "400"}]}
         )
       end
 
@@ -277,7 +277,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 4").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 4").to_h
         )
       end
 
@@ -287,7 +287,7 @@ RSpec.describe("v3.0 - Sources") do
         expect(response).to have_attributes(
           :status      => 400,
           :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add(400, "Invalid parameter - Validation failed: Availability status is not included in the list").to_h
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Availability status is not included in the list").to_h
         )
       end
 
@@ -335,7 +335,7 @@ RSpec.describe("v3.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 400,
-          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :created_at", "status" => 400 }]}
+          :parsed_body => { "errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :created_at", "status" => "400" }]}
         )
       end
     end
@@ -371,7 +371,7 @@ RSpec.describe("v3.0 - Sources") do
 
         expect(response).to have_attributes(
           :status      => 404,
-          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => 404}]}
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
         )
       end
 
@@ -538,7 +538,7 @@ RSpec.describe("v3.0 - Sources") do
 
             expect(response).to have_attributes(
               :status => 404,
-              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>404}]}
+              :parsed_body => {"errors"=>[{"detail"=>"Record not found", "status"=>"404"}]}
             )
           end
         end


### PR DESCRIPTION
This is needed to conform with the IPP which requires that error objects conform to the JSON API.

Uses the newer version of the common gem.

https://jsonapi.org/format/#errors
Which states that status is a string and not an integer.


https://projects.engineering.redhat.com/browse/TPINVTRY-925