### PR TITLE
Support log_level coming from environment variable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,7 @@ module Sources
     config.autoload_paths << Rails.root.join("app", "controllers", "mixins").to_s
     config.autoload_paths << Rails.root.join("lib").to_s
 
+    config.log_level = (ENV['RAILS_LOG_LEVEL'] || 'debug').downcase.to_sym
     Insights::API::Common::Logging.activate(config)
     Insights::API::Common::Metrics.activate(config, "sources_api")
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  # config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]


### PR DESCRIPTION
The environment variable is called RAILS_LOG_LEVEL with the valid values

 - info
 - debug
 - error
 - warn