### PR TITLE
Raise Kafka events when source and its associated applications are deleted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,8 @@ gem 'manageiq-messaging',   '~> 0.1.5', :require => false
 gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"
 gem 'more_core_extensions', '~> 3.5'
 gem 'pg',                   '~> 1.0', :require => false
-gem 'puma',                 '>= 4.3.3', '~> 4.3'
-gem 'rack-cors',            '>= 1.0.4', '~> 1.0'
+gem 'puma',                 '>= 4.3.5', '~> 4.3'
+gem 'rack-cors',            '>= 1.1.1', '~> 1.1'
 gem 'rails',                '~> 5.2.2'
 gem 'sprockets',            '~> 4.0'
 

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -1,7 +1,6 @@
 module Api
   module V1
     class ApplicationsController < ApplicationController
-      include Api::V1::Mixins::DestroyMixin
       include Api::V1::Mixins::IndexMixin
       include Api::V1::Mixins::ShowMixin
       include Api::V1::Mixins::UpdateMixin
@@ -10,6 +9,13 @@ module Api
         application = Application.create!(params_for_create)
         raise_event("#{model}.create", application.as_json)
         render :json => application, :status => :created, :location => instance_link(application)
+      end
+
+      def destroy
+        application = Application.find(params.require(:id))
+        application.destroy!
+
+        head :no_content
       end
     end
   end

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class ApplicationsController < ApplicationController
+      include Api::V1::Mixins::DestroyMixin
       include Api::V1::Mixins::IndexMixin
       include Api::V1::Mixins::ShowMixin
       include Api::V1::Mixins::UpdateMixin
@@ -9,13 +10,6 @@ module Api
         application = Application.create!(params_for_create)
         raise_event("#{model}.create", application.as_json)
         render :json => application, :status => :created, :location => instance_link(application)
-      end
-
-      def destroy
-        application = Application.find(params.require(:id))
-        application.destroy!
-
-        head :no_content
       end
     end
   end

--- a/app/controllers/api/v1/mixins/destroy_mixin.rb
+++ b/app/controllers/api/v1/mixins/destroy_mixin.rb
@@ -3,8 +3,7 @@ module Api
     module Mixins
       module DestroyMixin
         def destroy
-          record = model.destroy(params.require(:id))
-          raise_event("#{model}.destroy", record.as_json)
+          model.destroy(params.require(:id))
           head :no_content
         end
       end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -8,4 +8,15 @@ class Application < ApplicationRecord
 
   attribute :availability_status, :string
   validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
+
+  after_destroy :raise_event_message, :prepend => true
+
+  private
+
+  def raise_event_message
+    headers = Insights::API::Common::Request.current_forwardable
+    logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
+    Sources::Api::Events.raise_event("#{self.class}.destroy", self.as_json, headers)
+    logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
+  end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,5 +1,7 @@
 class Application < ApplicationRecord
   include TenancyConcern
+  include EventConcern
+
   belongs_to :source
   belongs_to :application_type
 
@@ -8,15 +10,4 @@ class Application < ApplicationRecord
 
   attribute :availability_status, :string
   validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
-
-  after_destroy :raise_event_message, :prepend => true
-
-  private
-
-  def raise_event_message
-    headers = Insights::API::Common::Request.current_forwardable
-    logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
-    Sources::Api::Events.raise_event("#{self.class}.destroy", self.as_json, headers)
-    logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
-  end
 end

--- a/app/models/application_authentication.rb
+++ b/app/models/application_authentication.rb
@@ -1,5 +1,6 @@
 class ApplicationAuthentication < ApplicationRecord
   include TenancyConcern
+  include EventConcern
   belongs_to :application
   belongs_to :authentication
 

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,6 +1,7 @@
 class Authentication < ApplicationRecord
   include PasswordConcern
   include TenancyConcern
+  include EventConcern
   encrypt_column :password
 
   belongs_to :resource, :polymorphic => true

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -1,0 +1,14 @@
+module EventConcern
+  extend ActiveSupport::Concern
+
+  included do
+    after_destroy :raise_event, :prepend => true
+  end
+
+  def raise_event
+    headers = Insights::API::Common::Request.current_forwardable
+    logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
+    Sources::Api::Events.raise_event("#{self.class}.destroy", self.as_json, headers)
+    logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
+  end
+end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,5 +1,6 @@
 class Endpoint < ApplicationRecord
   include TenancyConcern
+  include EventConcern
   belongs_to :source
 
   has_many   :authentications, :as => :resource, :dependent => :destroy

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,5 +1,6 @@
 class Source < ApplicationRecord
   include TenancyConcern
+  include EventConcern
   attribute :uid, :string, :default => -> { SecureRandom.uuid }
 
   has_many :applications, :dependent => :destroy

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -2,7 +2,7 @@ class Source < ApplicationRecord
   include TenancyConcern
   attribute :uid, :string, :default => -> { SecureRandom.uuid }
 
-  has_many :applications
+  has_many :applications, :dependent => :destroy
   has_many :application_types, :through => :applications
   has_many :endpoints, :autosave => true, :dependent => :destroy
 

--- a/spec/requests/api/v3.0/application_authentications_spec.rb
+++ b/spec/requests/api/v3.0/application_authentications_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
       it "success: with a valid paylod" do
         record = ApplicationAuthentication.create!(payload)
 
+        expect(Sources::Api::Events).to receive(:raise_event).once
         delete(instance_path(record.id), :headers => headers)
 
         expect(response.status).to eq(204)

--- a/spec/requests/api/v3.0/applications_spec.rb
+++ b/spec/requests/api/v3.0/applications_spec.rb
@@ -142,6 +142,20 @@ RSpec.describe("v3.0 - Applications") do
         )
       end
     end
+
+    context "delete" do
+      it "success: with a valid id" do
+        instance = Application.create!(payload.merge(:tenant => tenant))
+
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+    end
   end
 
   describe("/api/v3.0/applications/:id/authentications") do

--- a/spec/requests/api/v3.0/authentications_spec.rb
+++ b/spec/requests/api/v3.0/authentications_spec.rb
@@ -162,5 +162,19 @@ RSpec.describe("v3.0 - Authentications") do
         )
       end
     end
+
+    context "delete" do
+      let(:instance) { Authentication.create!(payload.merge(:tenant => tenant)) }
+
+      it "success: with a valid id" do
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+    end
   end
 end

--- a/spec/requests/api/v3.0/endpoints_spec.rb
+++ b/spec/requests/api/v3.0/endpoints_spec.rb
@@ -150,5 +150,37 @@ RSpec.describe("v3.0 - Endpoints") do
         )
       end
     end
+
+    context "delete" do
+      let(:instance) { Endpoint.create!(payload.merge(:tenant => tenant)) }
+
+      it "success: with a valid id" do
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+
+      it "success: with associated authentications" do
+        authentication_payload = {
+            "username"      => "test_name",
+            "password"      => "Test Password",
+            "resource_type" => "Tenant",
+            "resource_id"   => tenant.id.to_s
+          }
+        authentication = Authentication.create!(authentication_payload.merge(:tenant => tenant, :resource => instance))
+
+        expect(Sources::Api::Events).to receive(:raise_event).twice
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+    end
   end
 end

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -339,6 +339,47 @@ RSpec.describe("v3.0 - Sources") do
         )
       end
     end
+
+    context "delete" do
+      it "success: with a valid id" do
+        instance = Source.create!(attributes.merge("tenant" => tenant))
+
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status => 204,
+          :parsed_body => ""
+        )
+      end
+
+      it "success: with associated applications" do
+        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
+        instance    = Source.create!(attributes.merge("tenant" => tenant))
+
+        app_type1 = ApplicationType.create(:name         => "/platform/application-type1",
+                                           :display_name => "Application Type One")
+
+        app_type2 = ApplicationType.create(:name         => "ApplicationType2",
+                                           :display_name => "Application Type Two")
+
+        app_type1_url = "http://app1.example.com:8001/availability_check"
+        app_type2_url = "http://app2.example.com:8002/availability_check"
+
+        app1 = Application.create(:application_type => app_type1, :source => instance, :tenant => tenant)
+        app2 = Application.create(:application_type => app_type2, :source => instance, :tenant => tenant)
+
+        expect(Sources::Api::Events).to receive(:raise_event).exactly(3).times
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status => 204,
+          :parsed_body => ""
+        )
+        expect(Application.count).to eq(0)
+      end
+    end
   end
 
   describe("/api/v3.0/sources/:id/check_availability") do

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -370,7 +370,20 @@ RSpec.describe("v3.0 - Sources") do
         app1 = Application.create(:application_type => app_type1, :source => instance, :tenant => tenant)
         app2 = Application.create(:application_type => app_type2, :source => instance, :tenant => tenant)
 
-        expect(Sources::Api::Events).to receive(:raise_event).exactly(3).times
+        tenant_payload = {
+          "host"                  => "example.com",
+          "port"                  => 443,
+          "role"                  => "default",
+          "path"                  => "api",
+          "source_id"             => instance.id.to_s,
+          "scheme"                => "https",
+          "verify_ssl"            => true,
+          "certificate_authority" => "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----",
+        }
+
+        Endpoint.create!(tenant_payload.merge(:tenant => tenant, :source => instance))
+
+        expect(Sources::Api::Events).to receive(:raise_event).exactly(4).times
         delete(instance_path(instance.id), :headers => headers)
 
         expect(response).to have_attributes(


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-916

The logic of raising Kafka messages originally is defined in `application controller`'s destroy method (via `mixin`), so it will be missed even when `:dependent => :destroy` is set. This PR moved it into `after_destroy` callback, to guarantee message is sent out.