### PR TITLE
Adding nullable:true to availability_status_error

### DIFF
--- a/public/doc/openapi-3-v3.0.json
+++ b/public/doc/openapi-3-v3.0.json
@@ -1445,6 +1445,7 @@
             "type": "string"
           },
           "availability_status_error": {
+            "nullable": true,
             "type": "string"
           },
           "created_at": {
@@ -1595,6 +1596,7 @@
             "type": "string"
           },
           "availability_status_error": {
+            "nullable": true,
             "type": "string"
           },
           "extra": {
@@ -1706,6 +1708,7 @@
             "type": "string"
           },
           "availability_status_error": {
+            "nullable": true,
             "type": "string"
           },
           "certificate_authority": {


### PR DESCRIPTION
`availability_status_error` message needs to be nullable, because the message should be deleted when Source becomes available. 

---

[TPINVTRY-948](https://projects.engineering.redhat.com/browse/TPINVTRY-948)