### PR TITLE
Removed debug log messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -52,7 +52,7 @@ class ApplicationController < ActionController::API
         else
           ActsAsTenant.without_tenant { yield }
         end
-      rescue KeyError, Insights::API::Common::IdentityError => e
+      rescue KeyError, Insights::API::Common::IdentityError
         error_document = Insights::API::Common::ErrorDocument.new.add('401', 'Unauthorized')
         render :json => error_document.to_h, :status => error_document.status
       rescue Insights::API::Common::EntitlementError


### PR DESCRIPTION
Undo the log message changes from
PR #235 
PR #236 

Since it would be done cleanly by delegating it to the common gem.