### PR TITLE
Making authtype readonly(OpenAPI)

### DIFF
--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -30,6 +30,12 @@ class OpenapiGenerator < Insights::API::Common::OpenApi::Generator
       }
     end
   end
+
+  def schema_overrides
+    authentication = schemas['Authentication']
+    authentication['properties']['authtype']['readOnly'] = true
+    super.merge('Authentication' => authentication)
+  end
 end
 
 namespace :openapi do

--- a/public/doc/openapi-3-v3.0.json
+++ b/public/doc/openapi-3-v3.0.json
@@ -1589,7 +1589,8 @@
         "properties": {
           "authtype": {
             "example": "openshift_default",
-            "type": "string"
+            "type": "string",
+            "readOnly": true
           },
           "availability_status": {
             "type": "string"


### PR DESCRIPTION
 OpenAPI definitions: Add `readOnly` for authtype in Authentication

Based on https://projects.engineering.redhat.com/browse/TPINVTRY-932.