### PR TITLE
Make Authentication:authtype readonly only for updating

### DIFF
--- a/app/controllers/api/v1/mixins/update_mixin.rb
+++ b/app/controllers/api/v1/mixins/update_mixin.rb
@@ -4,6 +4,8 @@ module Api
       module UpdateMixin
         def update
           record = model.update(params.require(:id), params_for_update)
+          raise ActiveRecord::RecordInvalid.new(record) if record.invalid?
+
           raise_event("#{model}.update", record.as_json)
           head :no_content
         end

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -11,4 +11,12 @@ class Authentication < ApplicationRecord
 
   attribute :availability_status, :string
   validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
+
+  validate :authtype_not_updated
+
+  def authtype_not_updated
+    if !new_record? && authtype_changed?
+      errors.add(:authtype, "cannot be updated")
+    end
+  end
 end

--- a/lib/tasks/openapi_generate.rake
+++ b/lib/tasks/openapi_generate.rake
@@ -31,11 +31,12 @@ class OpenapiGenerator < Insights::API::Common::OpenApi::Generator
     end
   end
 
-  def schema_overrides
-    authentication = schemas['Authentication']
-    authentication['properties']['authtype']['readOnly'] = true
-    super.merge('Authentication' => authentication)
-  end
+  # TODO: make readOnly authtype only for update
+  # def schema_overrides
+  #   authentication = schemas['Authentication']
+  #   authentication['properties']['authtype']['readOnly'] = true
+  #   super.merge('Authentication' => authentication)
+  # end
 end
 
 namespace :openapi do

--- a/public/doc/openapi-3-v3.0.json
+++ b/public/doc/openapi-3-v3.0.json
@@ -1589,8 +1589,7 @@
         "properties": {
           "authtype": {
             "example": "openshift_default",
-            "type": "string",
-            "readOnly": true
+            "type": "string"
           },
           "availability_status": {
             "type": "string"

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,19 @@
+describe Authentication do
+  describe "#authtype_not_updated" do
+    let(:source_type) { SourceType.find_or_create_by!(:name => "amazon", :product_name => "Amazon Web Services", :vendor => "Amazon") }
+    let(:tenant) { Tenant.create!(:external_tenant => SecureRandom.uuid) }
+    let(:source) { Source.create!(:name => "my-source", :tenant => tenant, :source_type => source_type) }
+    let(:endpoint) { Endpoint.create!(:host => 'www.example.com', :tenant => tenant, :source => source) }
+
+    it "can create authentication with any authtype" do
+      expect { described_class.create!(:resource => endpoint, :authtype => 'username_password', :tenant => tenant) }.not_to raise_exception
+    end
+
+    it "can't update authentication's authtype" do
+      auth = described_class.create!(:resource => endpoint, :authtype => 'username_password', :tenant => tenant)
+
+      expect { auth.update!(:name => 'my_auth') }.not_to raise_exception
+      expect { auth.update!(:authtype => 'token') }.to raise_exception(ActiveRecord::RecordInvalid)
+    end
+  end
+end


### PR DESCRIPTION
**Issue**: #196 

We want to mark the authtype as readOnly only for PATCH request (update). As the openapi generator isn't prepared for it yet, this is a fast solution for it

---

Reverting: #240 

---

[TPINVTRY-932](https://projects.engineering.redhat.com/browse/TPINVTRY-932)