### PR TITLE
Set the first endpoint created on a source as default

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -11,7 +11,13 @@ class Endpoint < ApplicationRecord
   attribute :availability_status, :string
   validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
 
+  before_save :set_default, :if => proc { source.endpoints.count.zero? }
+
   def base_url_path
     URI::Generic.build(:scheme => scheme, :host => host, :port => port, :path => path).to_s
+  end
+
+  def set_default
+    self.default = true
   end
 end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -16,5 +16,23 @@ describe Endpoint do
       described_class.create!(:role => "first", :default => true, :tenant => tenant, :source => source)
       expect { described_class.create!(:role => "second", :default => true, :tenant => tenant, :source => source) }.to raise_exception
     end
+
+    it "sets the first endpoint created as default" do
+      endpoint = described_class.create!(:role => "first", :tenant => tenant, :source => source)
+      expect(endpoint.default).to be_truthy
+
+      endpoint2 = described_class.create!(:role => "second", :tenant => tenant, :source => source)
+      expect(endpoint2.default).to be_falsey
+    end
+
+    it "sets default on an endpoint that gets re-added" do
+      endpoint = described_class.create!(:role => "first", :tenant => tenant, :source => source)
+      expect(endpoint.default).to be_truthy
+
+      endpoint.delete
+
+      endpoint2 = described_class.create!(:role => "second", :tenant => tenant, :source => source)
+      expect(endpoint2.default).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-999

We are running into various issues where users create source/endpoint/authentication via API and if they do not pass in `default => true` in the POST /endpoints call, the source then doesn't know about an endpoint, which causes availability checks to show "Partially Available".

This way there is always a default endpoint for availability checking, even when created via the api.
