### PR TITLE
Modified tests to use FactoryBot.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :development, :test do
 end
 
 group :test do
-	gem "factory_bot_rails"
+  gem "factory_bot_rails"
   gem 'rspec-rails', '~>3.8'
   gem 'webmock'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ group :development, :test do
 end
 
 group :test do
+	gem "factory_bot_rails"
   gem 'rspec-rails', '~>3.8'
   gem 'webmock'
-  gem "factory_bot_rails"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,5 @@ end
 group :test do
   gem 'rspec-rails', '~>3.8'
   gem 'webmock'
+  gem "factory_bot_rails"
 end

--- a/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
@@ -5,8 +5,7 @@ describe Api::V1::Mixins::DestroyMixin do
     include ::Spec::Support::TenantIdentity
 
     let(:headers) {   {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-    let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
-    let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+    let!(:source_1)   { create(:source, name: "test_source 1") }
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
     before do
       allow(client).to receive(:publish_topic)
@@ -21,7 +20,7 @@ describe Api::V1::Mixins::DestroyMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { Endpoint.create!(:role => "a", :source => source_1, :tenant => tenant) }
+      let!(:endpoint_1) { create(:endpoint, role: "a", :source => source_1) }
 
       it "delete /sources/:id/endpoint/:id fails with 404" do
         delete(api_v1x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
@@ -5,7 +5,7 @@ describe Api::V1::Mixins::DestroyMixin do
     include ::Spec::Support::TenantIdentity
 
     let(:headers) {   {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-    let!(:source_1)   { create(:source, name: "test_source 1") }
+    let!(:source_1)   { create(:source, :name => "test_source 1") }
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
     before do
       allow(client).to receive(:publish_topic)
@@ -20,7 +20,7 @@ describe Api::V1::Mixins::DestroyMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { create(:endpoint, role: "a", source: source_1) }
+      let!(:endpoint_1) { create(:endpoint, :role => "a", :source => source_1) }
 
       it "delete /sources/:id/endpoint/:id fails with 404" do
         delete(api_v1x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/destroy_mixin_spec.rb
@@ -20,7 +20,7 @@ describe Api::V1::Mixins::DestroyMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { create(:endpoint, role: "a", :source => source_1) }
+      let!(:endpoint_1) { create(:endpoint, role: "a", source: source_1) }
 
       it "delete /sources/:id/endpoint/:id fails with 404" do
         delete(api_v1x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/index_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/index_mixin_spec.rb
@@ -3,8 +3,8 @@ describe Api::V1::Mixins::IndexMixin do
     include ::Spec::Support::TenantIdentity
 
     let(:headers)      { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-    let!(:source_1)    { create(:source, name: "test_source 1") }
-    let!(:source_2)    { create(:source, name: "test_source 2") }
+    let!(:source_1)    { create(:source, :name => "test_source 1") }
+    let!(:source_2)    { create(:source, :name => "test_source 2") }
 
     it "Primary Collection: get /sources lists all Sources" do
       get(api_v1x0_sources_url, :headers => headers)
@@ -14,9 +14,9 @@ describe Api::V1::Mixins::IndexMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { create(:endpoint, role: "a", source: source_1) }
-      let!(:endpoint_2) { create(:endpoint, role: "b", source: source_1) }
-      let!(:endpoint_3) { create(:endpoint, role: "c", source: source_2) }
+      let!(:endpoint_1) { create(:endpoint, :role => "a", :source => source_1) }
+      let!(:endpoint_2) { create(:endpoint, :role => "b", :source => source_1) }
+      let!(:endpoint_3) { create(:endpoint, :role => "c", :source => source_2) }
 
       it "get /sources/:id/endpoints lists all Endpoints for a source" do
         get(api_v1x0_source_endpoints_url(source_1.id), :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/index_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/index_mixin_spec.rb
@@ -3,9 +3,8 @@ describe Api::V1::Mixins::IndexMixin do
     include ::Spec::Support::TenantIdentity
 
     let(:headers)      { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-    let!(:source_1)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
-    let!(:source_2)    { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
-    let!(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+    let!(:source_1)    { create(:source, name: "test_source 1") }
+    let!(:source_2)    { create(:source, name: "test_source 2") }
 
     it "Primary Collection: get /sources lists all Sources" do
       get(api_v1x0_sources_url, :headers => headers)
@@ -15,9 +14,9 @@ describe Api::V1::Mixins::IndexMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { Endpoint.create!(:role => "a", :source => source_1, :tenant => tenant) }
-      let!(:endpoint_2) { Endpoint.create!(:role => "b", :source => source_1, :tenant => tenant) }
-      let!(:endpoint_3) { Endpoint.create!(:role => "c", :source => source_2, :tenant => tenant) }
+      let!(:endpoint_1) { create(:endpoint, role: "a", source: source_1) }
+      let!(:endpoint_2) { create(:endpoint, role: "b", source: source_1) }
+      let!(:endpoint_3) { create(:endpoint, role: "c", source: source_2) }
 
       it "get /sources/:id/endpoints lists all Endpoints for a source" do
         get(api_v1x0_source_endpoints_url(source_1.id), :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/show_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/show_mixin_spec.rb
@@ -14,7 +14,7 @@ describe Api::V1::Mixins::ShowMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { create(:endpoint, role: "a", :source => source_1) }
+      let!(:endpoint_1) { create(:endpoint, role: "a", source: source_1) }
 
       it "get /sources/:id/endpoints/:id doesn't exist" do
         get(api_v1x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/show_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/show_mixin_spec.rb
@@ -3,9 +3,8 @@ describe Api::V1::Mixins::ShowMixin do
     include ::Spec::Support::TenantIdentity
 
     let(:headers)     { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-    let!(:source_1)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 1", :uid => SecureRandom.uuid) }
-    let!(:source_2)   { Source.create!(:source_type => source_type, :tenant => tenant, :name => "test_source 2", :uid => SecureRandom.uuid) }
-    let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+    let!(:source_1)   { create(:source, name: "test_source 1") }
+    let!(:source_2)   { create(:source, name: "test_source 2") }
 
     it "Primary Collection: get /sources lists all Sources" do
       get(api_v1x0_source_url(source_1.id), :headers => headers)
@@ -15,7 +14,7 @@ describe Api::V1::Mixins::ShowMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { Endpoint.create!(:role => "a", :source => source_1, :tenant => tenant) }
+      let!(:endpoint_1) { create(:endpoint, role: "a", :source => source_1) }
 
       it "get /sources/:id/endpoints/:id doesn't exist" do
         get(api_v1x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/show_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/show_mixin_spec.rb
@@ -3,8 +3,8 @@ describe Api::V1::Mixins::ShowMixin do
     include ::Spec::Support::TenantIdentity
 
     let(:headers)     { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-    let!(:source_1)   { create(:source, name: "test_source 1") }
-    let!(:source_2)   { create(:source, name: "test_source 2") }
+    let!(:source_1)   { create(:source, :name => "test_source 1") }
+    let!(:source_2)   { create(:source, :name => "test_source 2") }
 
     it "Primary Collection: get /sources lists all Sources" do
       get(api_v1x0_source_url(source_1.id), :headers => headers)
@@ -14,7 +14,7 @@ describe Api::V1::Mixins::ShowMixin do
     end
 
     context "Sub-collection:" do
-      let!(:endpoint_1) { create(:endpoint, role: "a", source: source_1) }
+      let!(:endpoint_1) { create(:endpoint, :role => "a", :source => source_1) }
 
       it "get /sources/:id/endpoints/:id doesn't exist" do
         get(api_v1x0_source_endpoints_url(source_1.id) + "/#{endpoint_1.id}", :headers => headers)

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::Mixins::UpdateMixin do
     end
 
     it "patch /sources/:id updates a Source" do
-      source = create(:source, name: "abc")
+      source = create(:source, :name => "abc")
 
       patch(api_v1x0_source_url(source.id), :params => {:name => "xyz"}.to_json, :headers => headers)
 

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -13,7 +13,7 @@ describe Api::V1::Mixins::UpdateMixin do
     end
 
     it "patch /sources/:id updates a Source" do
-      source = create(:source, :name => "abc")
+      source = create(:source, name: "abc")
 
       patch(api_v1x0_source_url(source.id), :params => {:name => "xyz"}.to_json, :headers => headers)
 

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -5,7 +5,6 @@ describe Api::V1::Mixins::UpdateMixin do
     include ::Spec::Support::TenantIdentity
 
     let(:headers)     { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-    let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
 
     before do
@@ -14,7 +13,7 @@ describe Api::V1::Mixins::UpdateMixin do
     end
 
     it "patch /sources/:id updates a Source" do
-      source = Source.create!(:source_type => source_type, :tenant => tenant, :name => "abc", :uid => SecureRandom.uuid)
+      source = create(:source, :name => "abc")
 
       patch(api_v1x0_source_url(source.id), :params => {:name => "xyz"}.to_json, :headers => headers)
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe ApplicationController, :type => :request do
   include ::Spec::Support::TenantIdentity
-  let(:source_type) { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
-  let!(:source)     { Source.create!(:source_type_id => source_type.id, :tenant_id => tenant.id , :name => "abc", :uid => "123") }
+  let!(:source)     { create(:source, tenant: tenant, name: "abc", uid: "123") }
   let(:client)      { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ApplicationController, :type => :request do
   include ::Spec::Support::TenantIdentity
-  let!(:source)     { create(:source, tenant: tenant, name: "abc", uid: "123") }
+  let!(:source)     { create(:source, :tenant => tenant, :name => "abc", :uid => "123") }
   let(:client)      { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)

--- a/spec/controllers/internal/v1x0/authentications_controller_spec.rb
+++ b/spec/controllers/internal/v1x0/authentications_controller_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe Internal::V1x0::AuthenticationsController, :type => :request do
   include ::Spec::Support::TenantIdentity
-  
+ 
   let(:headers)        { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-  let(:authentication) { create(:authentication, resource: endpoint, password: "abcdefg") }
+  let(:authentication) { create(:authentication, :resource => endpoint, :password => "abcdefg") }
   let(:endpoint)       { create(:endpoint) }
 
   it "GET an instance" do

--- a/spec/controllers/internal/v1x0/authentications_controller_spec.rb
+++ b/spec/controllers/internal/v1x0/authentications_controller_spec.rb
@@ -1,10 +1,9 @@
 RSpec.describe Internal::V1x0::AuthenticationsController, :type => :request do
   include ::Spec::Support::TenantIdentity
+  
   let(:headers)        { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-  let(:authentication) { Authentication.create!(:resource => endpoint, :tenant => tenant, :password => "abcdefg") }
-  let(:endpoint)       { Endpoint.create!(:source => source, :tenant => tenant) }
-  let(:source)         { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
-  let(:source_type)    { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+  let(:authentication) { create(:authentication, resource: endpoint, password: "abcdefg") }
+  let(:endpoint)       { create(:endpoint) }
 
   it "GET an instance" do
     get(internal_v1x0_authentication_url(authentication.id), :headers => headers)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,24 +1,24 @@
 FactoryBot.define do
   factory :application do
     application_type { association(:application_type) }
-    source           { association(:source, tenant: tenant) }
+    source           { association(:source, :tenant => tenant) }
     tenant           { association(:tenant) }
   end
 
   factory :application_authentication do
-    application    { association(:application, tenant: tenant) }
+    application    { association(:application, :tenant => tenant) }
     authentication { association(:authentication) }
     tenant         { association(:tenant) }
   end
 
   factory :application_type do
-    name                   { "my-application-type"}
+    name                   { "my-application-type" }
     supported_source_types { ["my-source-type"] }
   end
 
   factory :authentication do
-    username {"test_name"}
-    password {"Test Password"}
+    username { "test_name" }
+    password { "Test Password" }
 
     tenant   { association(:tenant) }
   end
@@ -33,15 +33,15 @@ FactoryBot.define do
     certificate_authority { "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----" }
 
     tenant { association(:tenant) }
-    source { association(:source, tenant: tenant) }
+    source { association(:source, :tenant => tenant) }
   end
-  
+
   factory :source_type do
     transient do
       compatible { true }
     end
 
-    initialize_with { SourceType.find_or_create_by(name: name, product_name: product_name, vendor: vendor) }
+    initialize_with { SourceType.find_or_create_by(:name => name, :product_name => product_name, :vendor => vendor) }
 
     name         { compatible ? "my-source-type" : "not-my-source-type" }
     product_name { compatible ? "My Source Type" : "Not My Source Type" }
@@ -53,17 +53,17 @@ FactoryBot.define do
       compatible { true }
     end
 
-    initialize_with { Source.where(name: name).first_or_create(source_type: source_type, tenant: tenant, uid: uid) }
+    initialize_with { Source.where(:name => name).first_or_create(:source_type => source_type, :tenant => tenant, :uid => uid) }
     # initialize_with { Source.find_or_create_by(name: name, source_type: source_type, tenant: tenant) }
 
-    source_type { association(:source_type, compatible: compatible) }
+    source_type { association(:source_type, :compatible => compatible) }
     tenant      { association(:tenant) }
     name        { compatible ? "my-source" : "not-my-source" }
     uid         { SecureRandom.uuid }
   end
 
   factory :tenant do
-    initialize_with { Tenant.where(name: name).first_or_create(description: description, external_tenant: external_tenant) }
+    initialize_with { Tenant.where(:name => name).first_or_create(:description => description, :external_tenant => external_tenant) }
 
     name            { "default" }
     description     { "Test tenant" }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,72 @@
+FactoryBot.define do
+  factory :application do
+    application_type { association(:application_type) }
+    source           { association(:source, tenant: tenant) }
+    tenant           { association(:tenant) }
+  end
+
+  factory :application_authentication do
+    application    { association(:application, tenant: tenant) }
+    authentication { association(:authentication) }
+    tenant         { association(:tenant) }
+  end
+
+  factory :application_type do
+    name                   { "my-application-type"}
+    supported_source_types { ["my-source-type"] }
+  end
+
+  factory :authentication do
+    username {"test_name"}
+    password {"Test Password"}
+
+    tenant   { association(:tenant) }
+  end
+
+  factory :endpoint do
+    host                  { "example.com" }
+    port                  { 443 }
+    role                  { "default" }
+    path                  { "api" }
+    scheme                { "https" }
+    verify_ssl            { true }
+    certificate_authority { "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----" }
+
+    tenant { association(:tenant) }
+    source { association(:source, tenant: tenant) }
+  end
+  
+  factory :source_type do
+    transient do
+      compatible { true }
+    end
+
+    initialize_with { SourceType.find_or_create_by(name: name, product_name: product_name, vendor: vendor) }
+
+    name         { compatible ? "my-source-type" : "not-my-source-type" }
+    product_name { compatible ? "My Source Type" : "Not My Source Type" }
+    vendor       { "ACME" }
+  end
+
+  factory :source do
+    transient do
+      compatible { true }
+    end
+
+    initialize_with { Source.where(name: name).first_or_create(source_type: source_type, tenant: tenant, uid: uid) }
+    # initialize_with { Source.find_or_create_by(name: name, source_type: source_type, tenant: tenant) }
+
+    source_type { association(:source_type, compatible: compatible) }
+    tenant      { association(:tenant) }
+    name        { compatible ? "my-source" : "not-my-source" }
+    uid         { SecureRandom.uuid }
+  end
+
+  factory :tenant do
+    initialize_with { Tenant.where(name: name).first_or_create(description: description, external_tenant: external_tenant) }
+
+    name            { "default" }
+    description     { "Test tenant" }
+    external_tenant { rand(1000).to_s }
+  end
+end

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -24,10 +24,7 @@ RSpec.describe AvailabilityStatusListener do
 
     context "when body contains valid resource_type and id" do
       let(:endpoint) do
-        source_type = SourceType.find_or_create_by!(:name => "amazon", :product_name => "Amazon Web Services", :vendor => "Amazon")
-        tenant = Tenant.create!(:external_tenant => SecureRandom.uuid)
-        source = Source.create!(:name => "my-source", :tenant => tenant, :source_type => source_type)
-        Endpoint.create!(:role => "first", :default => true, :tenant => tenant, :source => source)
+        create(:endpoint, role: "first", default: true)
       end
       let(:resource_type) { "endpoint" }
       let(:resource_id)   { endpoint.id.to_s }

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe AvailabilityStatusListener do
 
     context "when body contains valid resource_type and id" do
       let(:endpoint) do
-        create(:endpoint, role: "first", default: true)
+        create(:endpoint, :role => "first", :default => true)
       end
       let(:resource_type) { "endpoint" }
       let(:resource_id)   { endpoint.id.to_s }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe("Application") do
   describe "create!" do
     subject do
-      create(:application, source: source)
+      create(:application, :source => source)
     end
 
     context "when the application supports the given source type" do
@@ -13,7 +13,7 @@ RSpec.describe("Application") do
     end
 
     context "when the application does not support the given source type" do
-      let(:source) { create(:source, compatible: false) }
+      let(:source) { create(:source, :compatible => false) }
 
       it "should raise RecordInvalid" do
         expect do

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,25 +1,11 @@
 RSpec.describe("Application") do
-  include ::Spec::Support::TenantIdentity
-
   describe "create!" do
-    let(:compatible_source)       { Source.create!(:source_type => compatible_source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "my-source") }
-    let(:compatible_source_type)  { SourceType.create!(:name => "my-source-type", :product_name => "My Source Type", :vendor => "ACME") }
-
-    let(:incompatible_source)       { Source.create!(:source_type => incompatible_source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "not-my-source") }
-    let(:incompatible_source_type)  { SourceType.create!(:name => "not-my-source-type", :product_name => "Not My Source Type", :vendor => "ACME") }
-
-    let(:application_type)  { ApplicationType.create!("name" => "my-application", :supported_source_types => ["my-source-type"]) }
-
     subject do
-      Application.create!({
-        :application_type_id => application_type.id,
-        :source_id           => source.id,
-        :tenant              => tenant
-      })
+      create(:application, source: source)
     end
 
     context "when the application supports the given source type" do
-      let(:source) { compatible_source }
+      let(:source) { create(:source) }
 
       it "should return an instance of Application" do
         expect(subject).to be_an_instance_of(Application)
@@ -27,7 +13,7 @@ RSpec.describe("Application") do
     end
 
     context "when the application does not support the given source type" do
-      let(:source) { incompatible_source }
+      let(:source) { create(:source, compatible: false) }
 
       it "should raise RecordInvalid" do
         expect do

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -10,7 +10,7 @@ describe Endpoint do
   end
 
   describe "#default" do
-    let(:source) { create(:source, tenant: tenant) }
+    let(:source) { create(:source, :tenant => tenant) }
 
     it "allows only one default endpoint" do
       described_class.create!(:role => "first", :default => true, :tenant => tenant, :source => source)

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -1,4 +1,6 @@
 describe Endpoint do
+  include ::Spec::Support::TenantIdentity
+
   describe "#base_url_path" do
     let(:endpoint) { described_class.new(:host => "www.example.com", :port => 1234, :scheme => "https") }
 
@@ -8,13 +10,11 @@ describe Endpoint do
   end
 
   describe "#default" do
-    let(:source_type) { SourceType.find_or_create_by!(:name => "amazon", :product_name => "Amazon Web Services", :vendor => "Amazon") }
-    let(:tenant) { Tenant.create!(:external_tenant => SecureRandom.uuid) }
-    let(:source) { Source.create!(:name => "my-source", :tenant => tenant, :source_type => source_type) }
+    let(:source) { create(:source, tenant: tenant) }
 
     it "allows only one default endpoint" do
       described_class.create!(:role => "first", :default => true, :tenant => tenant, :source => source)
-      expect { described_class.create!(:role => "second", :default => true, :tenant => tenant, :source => source) }.to raise_exception
+      expect { described_class.create!(:role => "second", :default => true, :tenant => tenant, :source => source) }.to raise_exception(ActiveRecord::RecordInvalid)
     end
 
     it "sets the first endpoint created as default" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/api/graphql_controller_spec.rb
+++ b/spec/requests/api/graphql_controller_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe("v1.0 - GraphQL") do
   include ::Spec::Support::TenantIdentity
-  let!(:source)      { create(:source, tenant: tenant, name: "sample_source", uid: "123") }
+  let!(:source) { create(:source, :tenant => tenant, :name => "sample_source", :uid => "123") }
 
   let!(:graphql_source_query) { { "query" => "{ sources(id: \"#{source.id}\") { tenant } }" }.to_json }
 

--- a/spec/requests/api/graphql_controller_spec.rb
+++ b/spec/requests/api/graphql_controller_spec.rb
@@ -1,7 +1,6 @@
 RSpec.describe("v1.0 - GraphQL") do
   include ::Spec::Support::TenantIdentity
-  let!(:source_type) { SourceType.create!(:name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
-  let!(:source)      { Source.create!(:tenant_id => tenant.id, :name => "sample_source", :source_type => source_type, :uid => "123") }
+  let!(:source)      { create(:source, tenant: tenant, name: "sample_source", uid: "123") }
 
   let!(:graphql_source_query) { { "query" => "{ sources(id: \"#{source.id}\") { tenant } }" }.to_json }
 

--- a/spec/requests/api/v1.0/application_types_spec.rb
+++ b/spec/requests/api/v1.0/application_types_spec.rb
@@ -2,8 +2,14 @@ RSpec.describe("v1.0 - ApplicationTypes") do
   include ::Spec::Support::TenantIdentity
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-  let(:attributes)      { {"name" => "my application type"} }
   let(:collection_path) { "/api/v1.0/application_types" }
+
+  let(:attributes) do
+    {
+      "name"                   => "my-application-type",
+      "supported_source_types" => ["my-source-type"]
+    }
+  end
 
   describe("/api/v1.0/application_types") do
     context "get" do
@@ -17,7 +23,7 @@ RSpec.describe("v1.0 - ApplicationTypes") do
       end
 
       it "success: non-empty collection" do
-        ApplicationType.create!(attributes)
+        create(:application_type, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -36,7 +42,7 @@ RSpec.describe("v1.0 - ApplicationTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = ApplicationType.create!(attributes)
+        instance = create(:application_type, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -47,7 +53,7 @@ RSpec.describe("v1.0 - ApplicationTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = ApplicationType.create!(attributes)
+        instance = create(:application_type, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -74,7 +80,7 @@ RSpec.describe("v1.0 - ApplicationTypes") do
 
         context "get" do
           it "success: with a valid id" do
-            instance = ApplicationType.create!(attributes)
+            instance = create(:application_type, attributes)
 
             get(subcollection_path(instance.id), :headers => headers)
 
@@ -85,7 +91,7 @@ RSpec.describe("v1.0 - ApplicationTypes") do
           end
 
           it "failure: with an invalid id" do
-            instance   = ApplicationType.create!(attributes)
+            instance   = create(:application_type, attributes)
             missing_id = (instance.id * 1000)
             expect(ApplicationType.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v1.0/authentications_spec.rb
+++ b/spec/requests/api/v1.0/authentications_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe("v1.0 - Authentications") do
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path) { "/api/v1.0/authentications" }
+
+  # Payload for the API request
   let(:payload) do
     {
       "username"      => "test_name",
@@ -32,7 +34,7 @@ RSpec.describe("v1.0 - Authentications") do
       end
 
       it "success: non-empty collection" do
-        Authentication.create!(payload.merge(:tenant => tenant))
+        create(:authentication, payload)
 
         get(collection_path, :headers => headers)
 
@@ -106,7 +108,7 @@ RSpec.describe("v1.0 - Authentications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Authentication.create!(payload.merge(:tenant => tenant))
+        instance = create(:authentication, payload)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -117,7 +119,7 @@ RSpec.describe("v1.0 - Authentications") do
       end
 
       it "failure: with an invalid id" do
-        instance = Authentication.create!(payload.merge(:tenant => tenant))
+        instance = create(:authentication, payload)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -129,7 +131,7 @@ RSpec.describe("v1.0 - Authentications") do
     end
 
     context "patch" do
-      let(:instance) { Authentication.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:authentication, payload) }
       it "success: with a valid id" do
         new_attributes = {"name" => "new name"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v1.0/endpoints_spec.rb
+++ b/spec/requests/api/v1.0/endpoints_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe("v1.0 - Endpoints") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = create(:endpoint, tenant: tenant)
+        instance = create(:endpoint, :tenant => tenant)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -102,7 +102,7 @@ RSpec.describe("v1.0 - Endpoints") do
       end
 
       it "failure: with an invalid id" do
-        instance = create(:endpoint, tenant: tenant)
+        instance = create(:endpoint, :tenant => tenant)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -114,7 +114,7 @@ RSpec.describe("v1.0 - Endpoints") do
     end
 
     context "patch" do
-      let(:instance) { create(:endpoint, tenant: tenant) }
+      let(:instance) { create(:endpoint, :tenant => tenant) }
       it "success: with a valid id" do
         new_attributes = {"host" => "example.org"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v1.0/endpoints_spec.rb
+++ b/spec/requests/api/v1.0/endpoints_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe("v1.0 - Endpoints") do
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path) { "/api/v1.0/endpoints" }
-  let(:source)          { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
-  let(:source_type)     { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+  let(:source)          { create(:source) }
 
+  # Payload for the API request
   let(:payload) do
     {
       "host"                  => "example.com",
@@ -39,7 +39,7 @@ RSpec.describe("v1.0 - Endpoints") do
       end
 
       it "success: non-empty collection" do
-        Endpoint.create!(payload.merge(:tenant => tenant))
+        create(:endpoint, payload)
 
         get(collection_path, :headers => headers)
 
@@ -91,7 +91,7 @@ RSpec.describe("v1.0 - Endpoints") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Endpoint.create!(payload.merge(:tenant => tenant))
+        instance = create(:endpoint, tenant: tenant)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -102,7 +102,7 @@ RSpec.describe("v1.0 - Endpoints") do
       end
 
       it "failure: with an invalid id" do
-        instance = Endpoint.create!(payload.merge(:tenant => tenant))
+        instance = create(:endpoint, tenant: tenant)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -114,7 +114,7 @@ RSpec.describe("v1.0 - Endpoints") do
     end
 
     context "patch" do
-      let(:instance) { Endpoint.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:endpoint, tenant: tenant) }
       it "success: with a valid id" do
         new_attributes = {"host" => "example.org"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe("Sources Filtering") do
   let(:headers)           { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:api_version)       { "v1.0" }
   let(:source_collection) { "/api/#{api_version}/sources" }
-  let(:source_type)       { SourceType.create!(:name => "SampleSourceType", :vendor => "Sample Vendor", :product_name => "Sample Product Name") }
 
   def create_source(source_name, opt_params = {})
-    Source.create!({:name => source_name, :source_type_id => source_type.id, :tenant => tenant}.merge(opt_params))
+    create(:source, {:name => source_name}.merge(opt_params))
   end
 
   def expect_success(query, *results)
@@ -55,8 +54,8 @@ RSpec.describe("Sources Filtering") do
 
   context "sorted results via sort_by" do
     before do
-      Source.create!(:name => "sort_by_source_a", :source_type => source_type, :tenant => tenant)
-      Source.create!(:name => "sort_by_source_b", :source_type => source_type, :tenant => tenant)
+      create_source("sort_by_source_a")
+      create_source("sort_by_source_b")
     end
 
     it "available for sources with default order" do

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe("v1.0 - SourceTypes") do
       end
 
       it "success: non-empty collection" do
-        SourceType.create!(attributes)
+        create(:source_type, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -76,7 +76,7 @@ RSpec.describe("v1.0 - SourceTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -87,7 +87,7 @@ RSpec.describe("v1.0 - SourceTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -106,7 +106,7 @@ RSpec.describe("v1.0 - SourceTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(subcollection_path(instance.id, "sources"), :headers => headers)
 
@@ -117,7 +117,7 @@ RSpec.describe("v1.0 - SourceTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
         missing_id = (instance.id * 1000)
         expect(Source.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v1.0 - Sources") do
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v1.0/sources" }
-  let(:source_type)     { create(:source_type, name: "SourceType", vendor: "Some Vendor", product_name: "Product Name") }
+  let(:source_type)     { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
@@ -386,7 +386,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid openshift source" do
-        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -409,7 +409,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid amazon source" do
-        source_type = create(:source_type, name: "amazon", vendor: "Amazon", product_name: "Amazon Web Services")
+        source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -432,7 +432,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with a source-type that topology doesn't support" do
-        source_type = create(:source_type, name: "vsphere", vendor: "VMware", product_name: "VMware vSphere")
+        source_type = create(:source_type, :name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -446,25 +446,25 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid openshift source querying associated applications" do
-        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
         app_type1 = create(:application_type,
-                           name:                   "/platform/application-type1",
-                           display_name:           "Application Type One",
-                           supported_source_types: ["openshift"])
+                           :name                   => "/platform/application-type1",
+                           :display_name           => "Application Type One",
+                           :supported_source_types => ["openshift"])
 
         app_type2 = create(:application_type,
-                           name:                   "ApplicationType2",
-                           display_name:           "Application Type Two",
-                           supported_source_types: ["openshift"])
+                           :name                   => "ApplicationType2",
+                           :display_name           => "Application Type Two",
+                           :supported_source_types => ["openshift"])
 
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = create(:application, application_type: app_type1, source: source, tenant: tenant)
-        app2 = create(:application, application_type: app_type2, source: source, tenant: tenant)
+        app1 = create(:application, :application_type => app_type1, :source => source, :tenant => tenant)
+        app2 = create(:application, :application_type => app_type2, :source => source, :tenant => tenant)
 
         source.applications = [app1, app2]
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid openshift source" do
-        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -409,7 +409,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid amazon source" do
-        source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
+        source_type = create(:source_type, name: "amazon", vendor: "Amazon", product_name: "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -432,7 +432,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with a source-type that topology doesn't support" do
-        source_type = create(:source_type, :name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
+        source_type = create(:source_type, name: "vsphere", vendor: "VMware", product_name: "VMware vSphere")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -446,7 +446,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid openshift source querying associated applications" do
-        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v1.0 - Sources") do
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v1.0/sources" }
-  let(:source_type)     { SourceType.create!(:name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
+  let(:source_type)     { create(:source_type, name: "SourceType", vendor: "Some Vendor", product_name: "Product Name") }
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
@@ -26,7 +26,7 @@ RSpec.describe("v1.0 - Sources") do
         end
 
         it "success: non-empty collection" do
-          Source.create!(attributes.merge("tenant" => tenant))
+          create(:source, attributes.merge("tenant" => tenant))
 
           get(collection_path, :headers => headers)
 
@@ -50,7 +50,7 @@ RSpec.describe("v1.0 - Sources") do
         end
 
         it "success: non-empty collection" do
-          Source.create!(attributes.merge("tenant" => tenant))
+          create(:source, attributes.merge("tenant" => tenant))
 
           get(collection_path, :headers => headers)
 
@@ -194,7 +194,7 @@ RSpec.describe("v1.0 - Sources") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -205,7 +205,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "failure: with an invalid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -218,7 +218,7 @@ RSpec.describe("v1.0 - Sources") do
 
     context "patch" do
       it "success: with a valid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -232,7 +232,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "failure: with a null value" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => nil}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -246,7 +246,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "failure: with an invalid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name"}
 
         patch(instance_path(instance.id * 1000), :params => new_attributes.to_json, :headers => headers)
@@ -258,7 +258,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "failure: with extra parameters" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"aaaaa" => "bbbbb"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -270,7 +270,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "failure: with read-only parameters" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"uid" => "xxxxx"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -338,7 +338,7 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "rejects read_only attributes" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name", "tenant" => "123456"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -386,9 +386,9 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid openshift source" do
-        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => openshift_topic,
@@ -409,9 +409,9 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid amazon source" do
-        source_type = SourceType.create!(:name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
+        source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => amazon_topic,
@@ -432,9 +432,9 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with a source-type that topology doesn't support" do
-        source_type = SourceType.create!(:name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
+        source_type = create(:source_type, :name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).not_to receive(:publish_topic)
         post(check_availability_path(source.id), :headers => headers)
@@ -446,23 +446,25 @@ RSpec.describe("v1.0 - Sources") do
       end
 
       it "success: with valid openshift source querying associated applications" do
-        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
-        app_type1 = ApplicationType.create(:name         => "/platform/application-type1",
-                                           :display_name => "Application Type One",
-                                           :supported_source_types => ["openshift"])
+        app_type1 = create(:application_type,
+                           name:                   "/platform/application-type1",
+                           display_name:           "Application Type One",
+                           supported_source_types: ["openshift"])
 
-        app_type2 = ApplicationType.create(:name         => "ApplicationType2",
-                                           :display_name => "Application Type Two",
-                                           :supported_source_types => ["openshift"])
+        app_type2 = create(:application_type,
+                           name:                   "ApplicationType2",
+                           display_name:           "Application Type Two",
+                           supported_source_types: ["openshift"])
 
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = Application.create(:application_type => app_type1, :source => source, :tenant => tenant)
-        app2 = Application.create(:application_type => app_type2, :source => source, :tenant => tenant)
+        app1 = create(:application, application_type: app_type1, source: source, tenant: tenant)
+        app2 = create(:application, application_type: app_type2, source: source, tenant: tenant)
 
         source.applications = [app1, app2]
 
@@ -531,7 +533,7 @@ RSpec.describe("v1.0 - Sources") do
 
         context "get" do
           it "success: with a valid id" do
-            instance = Source.create!(attributes.merge("tenant" => tenant))
+            instance = create(:source, attributes.merge("tenant" => tenant))
 
             get(subcollection_path(instance.id), :headers => headers)
 
@@ -542,7 +544,7 @@ RSpec.describe("v1.0 - Sources") do
           end
 
           it "failure: with an invalid id" do
-            instance = Source.create!(attributes.merge("tenant" => tenant))
+            instance = create(:source, attributes.merge("tenant" => tenant))
             missing_id = (instance.id * 1000)
             expect(Source.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v2.0/application_authentications_spec.rb
+++ b/spec/requests/api/v2.0/application_authentications_spec.rb
@@ -8,12 +8,9 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
   end
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-  let(:source_type)      { SourceType.create!(:name => "my-source-type", :product_name => "My Source Type", :vendor => "ACME") }
-  let(:source)           { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "my-source") }
-  let(:application_type) { ApplicationType.create!(:name => "my-app", :supported_source_types => ["my-source-type"]) }
-  let(:endpoint)         { Endpoint.create!(:source => source, :tenant => tenant) }
-  let(:authentication)   { Authentication.create!(:tenant => tenant, :resource => endpoint) }
-  let(:application)      { Application.create!(:application_type => application_type, :source => source, :tenant => tenant) }
+  let(:endpoint)         { create(:endpoint) }
+  let(:authentication)   { create(:authentication, resource: endpoint) }
+  let(:application)      { create(:application) }
   let(:attributes)       { {"application_id" => application.id.to_s, "authentication_id" => authentication.id.to_s } }
   let(:collection_path)  { "/api/v2.0/application_authentications" }
   let(:payload) do
@@ -35,7 +32,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
       end
 
       it "success: non-empty collection" do
-        ApplicationAuthentication.create!(attributes.merge(:tenant => tenant))
+        create(:application_authentication, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -86,7 +83,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = ApplicationAuthentication.create!(attributes.merge(:tenant => tenant))
+        instance = create(:application_authentication, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -97,7 +94,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
       end
 
       it "failure: with an invalid id" do
-        instance = ApplicationAuthentication.create!(attributes.merge(:tenant => tenant))
+        instance = create(:application_authentication, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -111,7 +108,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
 
     context "delete" do
       it "success: with a valid paylod" do
-        record = ApplicationAuthentication.create!(payload)
+        record = create(:application_authentication, payload)
 
         delete(instance_path(record.id), :headers => headers)
 

--- a/spec/requests/api/v2.0/application_authentications_spec.rb
+++ b/spec/requests/api/v2.0/application_authentications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe("v2.0 - ApplicationAuthentications") do
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:endpoint)         { create(:endpoint) }
-  let(:authentication)   { create(:authentication, resource: endpoint) }
+  let(:authentication)   { create(:authentication, :resource => endpoint) }
   let(:application)      { create(:application) }
   let(:attributes)       { {"application_id" => application.id.to_s, "authentication_id" => authentication.id.to_s } }
   let(:collection_path)  { "/api/v2.0/application_authentications" }

--- a/spec/requests/api/v2.0/application_types_spec.rb
+++ b/spec/requests/api/v2.0/application_types_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("v2.0 - ApplicationTypes") do
       end
 
       it "success: non-empty collection" do
-        ApplicationType.create!(attributes)
+        create(:application_type, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -36,7 +36,7 @@ RSpec.describe("v2.0 - ApplicationTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = ApplicationType.create!(attributes)
+        instance = create(:application_type, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -47,7 +47,7 @@ RSpec.describe("v2.0 - ApplicationTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = ApplicationType.create!(attributes)
+        instance = create(:application_type, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -74,7 +74,7 @@ RSpec.describe("v2.0 - ApplicationTypes") do
 
         context "get" do
           it "success: with a valid id" do
-            instance = ApplicationType.create!(attributes)
+            instance = create(:application_type, attributes)
 
             get(subcollection_path(instance.id), :headers => headers)
 
@@ -85,7 +85,7 @@ RSpec.describe("v2.0 - ApplicationTypes") do
           end
 
           it "failure: with an invalid id" do
-            instance   = ApplicationType.create!(attributes)
+            instance   = create(:application_type, attributes)
             missing_id = (instance.id * 1000)
             expect(ApplicationType.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v2.0/applications_spec.rb
+++ b/spec/requests/api/v2.0/applications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe("v2.0 - Applications") do
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path)  { "/api/v2.0/applications" }
-  let(:source)           { create(:source, tenant: tenant, uid: SecureRandom.uuid) }
+  let(:source)           { create(:source, :tenant => tenant, :uid => SecureRandom.uuid) }
   let(:application_type) { create(:application_type) }
   let(:payload) do
     {

--- a/spec/requests/api/v2.0/applications_spec.rb
+++ b/spec/requests/api/v2.0/applications_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe("v2.0 - Applications") do
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path)  { "/api/v2.0/applications" }
-  let(:source)           { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "my-source") }
-  let(:source_type)      { SourceType.create!(:name => "my-source-type", :product_name => "My Source Type", :vendor => "ACME") }
-  let(:application_type) { ApplicationType.create!("name" => "my-application", :supported_source_types => ["my-source-type"]) }
+  let(:source)           { create(:source, tenant: tenant, uid: SecureRandom.uuid) }
+  let(:application_type) { create(:application_type) }
   let(:payload) do
     {
       "source_id" => source.id.to_s,
@@ -31,7 +30,7 @@ RSpec.describe("v2.0 - Applications") do
       end
 
       it "success: non-empty collection" do
-        Application.create!(payload.merge(:tenant => tenant))
+        create(:application, payload.merge(:tenant => tenant))
 
         get(collection_path, :headers => headers)
 
@@ -83,7 +82,7 @@ RSpec.describe("v2.0 - Applications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -94,7 +93,7 @@ RSpec.describe("v2.0 - Applications") do
       end
 
       it "failure: with an invalid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -106,7 +105,7 @@ RSpec.describe("v2.0 - Applications") do
     end
 
     context "patch" do
-      let(:instance) { Application.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:application, payload.merge(:tenant => tenant)) }
       it "success: with a valid id" do
         new_attributes = {"availability_status" => "available"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -151,7 +150,7 @@ RSpec.describe("v2.0 - Applications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
 
         get(subcollection_path(instance.id, "authentications"), :headers => headers)
 
@@ -162,7 +161,7 @@ RSpec.describe("v2.0 - Applications") do
       end
 
       it "failure: with an invalid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
         missing_id = (instance.id * 1000)
         expect(Application.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v2.0/authentications_spec.rb
+++ b/spec/requests/api/v2.0/authentications_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe("v2.0 - Authentications") do
       end
 
       it "success: non-empty collection" do
-        Authentication.create!(payload.merge(:tenant => tenant))
+        create(:authentication, payload.merge(:tenant => tenant))
 
         get(collection_path, :headers => headers)
 
@@ -106,7 +106,7 @@ RSpec.describe("v2.0 - Authentications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Authentication.create!(payload.merge(:tenant => tenant))
+        instance = create(:authentication, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -117,7 +117,7 @@ RSpec.describe("v2.0 - Authentications") do
       end
 
       it "failure: with an invalid id" do
-        instance = Authentication.create!(payload.merge(:tenant => tenant))
+        instance = create(:authentication, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -129,7 +129,7 @@ RSpec.describe("v2.0 - Authentications") do
     end
 
     context "patch" do
-      let(:instance) { Authentication.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:authentication, payload.merge(:tenant => tenant)) }
       it "success: with a valid id" do
         new_attributes = {"name" => "new name"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v2.0/endpoints_spec.rb
+++ b/spec/requests/api/v2.0/endpoints_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe("v2.0 - Endpoints") do
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path) { "/api/v2.0/endpoints" }
-  let(:source)          { create(:source, tenant: tenant) }
+  let(:source)          { create(:source, :tenant => tenant) }
 
   let(:payload) do
     {

--- a/spec/requests/api/v2.0/endpoints_spec.rb
+++ b/spec/requests/api/v2.0/endpoints_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe("v2.0 - Endpoints") do
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path) { "/api/v2.0/endpoints" }
-  let(:source)          { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
-  let(:source_type)     { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+  let(:source)          { create(:source, tenant: tenant) }
 
   let(:payload) do
     {
@@ -39,7 +38,7 @@ RSpec.describe("v2.0 - Endpoints") do
       end
 
       it "success: non-empty collection" do
-        Endpoint.create!(payload.merge(:tenant => tenant))
+        create(:endpoint, payload.merge(:tenant => tenant))
 
         get(collection_path, :headers => headers)
 
@@ -91,7 +90,7 @@ RSpec.describe("v2.0 - Endpoints") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Endpoint.create!(payload.merge(:tenant => tenant))
+        instance = create(:endpoint, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -102,7 +101,7 @@ RSpec.describe("v2.0 - Endpoints") do
       end
 
       it "failure: with an invalid id" do
-        instance = Endpoint.create!(payload.merge(:tenant => tenant))
+        instance = create(:endpoint, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -114,7 +113,7 @@ RSpec.describe("v2.0 - Endpoints") do
     end
 
     context "patch" do
-      let(:instance) { Endpoint.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:endpoint, payload.merge(:tenant => tenant)) }
       it "success: with a valid id" do
         new_attributes = {"host" => "example.org"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v2.0/filter_spec.rb
+++ b/spec/requests/api/v2.0/filter_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe("Sources Filtering") do
   let(:headers)           { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:api_version)       { "v2.0" }
   let(:source_collection) { "/api/#{api_version}/sources" }
-  let(:source_type)       { SourceType.create!(:name => "SampleSourceType", :vendor => "Sample Vendor", :product_name => "Sample Product Name") }
 
   def create_source(source_name, opt_params = {})
-    Source.create!({:name => source_name, :source_type_id => source_type.id, :tenant => tenant}.merge(opt_params))
+    create(:source, {:name => source_name}.merge(opt_params))
   end
 
   def expect_success(query, *results)
@@ -55,8 +54,8 @@ RSpec.describe("Sources Filtering") do
 
   context "sorted results via sort_by" do
     before do
-      Source.create!(:name => "sort_by_source_a", :source_type => source_type, :tenant => tenant)
-      Source.create!(:name => "sort_by_source_b", :source_type => source_type, :tenant => tenant)
+      create(:source, name: "sort_by_source_a")
+      create(:source, name: "sort_by_source_b")
     end
 
     it "available for sources with default order" do

--- a/spec/requests/api/v2.0/filter_spec.rb
+++ b/spec/requests/api/v2.0/filter_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe("Sources Filtering") do
 
   context "sorted results via sort_by" do
     before do
-      create(:source, name: "sort_by_source_a")
-      create(:source, name: "sort_by_source_b")
+      create(:source, :name => "sort_by_source_a")
+      create(:source, :name => "sort_by_source_b")
     end
 
     it "available for sources with default order" do

--- a/spec/requests/api/v2.0/source_types_spec.rb
+++ b/spec/requests/api/v2.0/source_types_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe("v2.0 - SourceTypes") do
       end
 
       it "success: non-empty collection" do
-        SourceType.create!(attributes)
+        create(:source_type, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -49,7 +49,7 @@ RSpec.describe("v2.0 - SourceTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -60,7 +60,7 @@ RSpec.describe("v2.0 - SourceTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -79,7 +79,7 @@ RSpec.describe("v2.0 - SourceTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(subcollection_path(instance.id, "sources"), :headers => headers)
 
@@ -90,7 +90,7 @@ RSpec.describe("v2.0 - SourceTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
         missing_id = (instance.id * 1000)
         expect(Source.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v2.0 - Sources") do
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v2.0/sources" }
-  let(:source_type)     { SourceType.create!(:name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
+  let(:source_type)     { create(:source_type, name: "SourceType", vendor: "Some Vendor", product_name: "Product Name") }
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
@@ -26,7 +26,7 @@ RSpec.describe("v2.0 - Sources") do
         end
 
         it "success: non-empty collection" do
-          Source.create!(attributes.merge("tenant" => tenant))
+          create(:source, attributes.merge("tenant" => tenant))
 
           get(collection_path, :headers => headers)
 
@@ -50,7 +50,7 @@ RSpec.describe("v2.0 - Sources") do
         end
 
         it "success: non-empty collection" do
-          Source.create!(attributes.merge("tenant" => tenant))
+          create(:source, attributes.merge("tenant" => tenant))
 
           get(collection_path, :headers => headers)
 
@@ -184,7 +184,7 @@ RSpec.describe("v2.0 - Sources") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -195,7 +195,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "failure: with an invalid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -208,7 +208,7 @@ RSpec.describe("v2.0 - Sources") do
 
     context "patch" do
       it "success: with a valid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -222,7 +222,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "failure: with a null value" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => nil}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -236,7 +236,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "failure: with an invalid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name"}
 
         patch(instance_path(instance.id * 1000), :params => new_attributes.to_json, :headers => headers)
@@ -248,7 +248,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "failure: with extra parameters" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"aaaaa" => "bbbbb"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -260,7 +260,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "failure: with read-only parameters" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"uid" => "xxxxx"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -328,7 +328,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "rejects read_only attributes" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name", "created_at" => Time.now.utc}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -376,9 +376,9 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with valid openshift source" do
-        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => openshift_topic,
@@ -399,9 +399,9 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with valid amazon source" do
-        source_type = SourceType.create!(:name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
+        source_type = create(:source_type, name: "amazon", vendor: "Amazon", product_name: "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => amazon_topic,
@@ -422,9 +422,9 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with a source-type that topology doesn't support" do
-        source_type = SourceType.create!(:name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
+        source_type = create(:source_type, name: "vsphere", vendor: "VMware", product_name: "VMware vSphere")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).not_to receive(:publish_topic)
         post(check_availability_path(source.id), :headers => headers)
@@ -436,23 +436,25 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with valid openshift source querying associated applications" do
-        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
-        app_type1 = ApplicationType.create(:name         => "/platform/application-type1",
-                                           :display_name => "Application Type One",
-                                           :supported_source_types => ["openshift"])
+        app_type1 = create(:application_type,
+                           name:                   "/platform/application-type1",
+                           display_name:           "Application Type One",
+                           supported_source_types: ["openshift"])
 
-        app_type2 = ApplicationType.create(:name         => "ApplicationType2",
-                                           :display_name => "Application Type Two",
-                                           :supported_source_types => ["openshift"])
+        app_type2 = create(:application_type,
+                           name:                   "ApplicationType2",
+                           display_name:           "Application Type Two",
+                           supported_source_types: ["openshift"])
 
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = Application.create(:application_type => app_type1, :source => source, :tenant => tenant)
-        app2 = Application.create(:application_type => app_type2, :source => source, :tenant => tenant)
+        app1 = create(:application, application_type: app_type1, source: source, tenant: tenant)
+        app2 = create(:application, application_type: app_type2, source: source, tenant: tenant)
 
         source.applications = [app1, app2]
 
@@ -521,7 +523,7 @@ RSpec.describe("v2.0 - Sources") do
 
         context "get" do
           it "success: with a valid id" do
-            instance = Source.create!(attributes.merge("tenant" => tenant))
+            instance = create(:source, attributes.merge("tenant" => tenant))
 
             get(subcollection_path(instance.id), :headers => headers)
 
@@ -532,7 +534,7 @@ RSpec.describe("v2.0 - Sources") do
           end
 
           it "failure: with an invalid id" do
-            instance = Source.create!(attributes.merge("tenant" => tenant))
+            instance = create(:source, attributes.merge("tenant" => tenant))
             missing_id = (instance.id * 1000)
             expect(Source.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v2.0 - Sources") do
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v2.0/sources" }
-  let(:source_type)     { create(:source_type, name: "SourceType", vendor: "Some Vendor", product_name: "Product Name") }
+  let(:source_type)     { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
@@ -376,7 +376,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with valid openshift source" do
-        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -399,7 +399,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with valid amazon source" do
-        source_type = create(:source_type, name: "amazon", vendor: "Amazon", product_name: "Amazon Web Services")
+        source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -422,7 +422,7 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with a source-type that topology doesn't support" do
-        source_type = create(:source_type, name: "vsphere", vendor: "VMware", product_name: "VMware vSphere")
+        source_type = create(:source_type, :name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -436,25 +436,25 @@ RSpec.describe("v2.0 - Sources") do
       end
 
       it "success: with valid openshift source querying associated applications" do
-        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
         app_type1 = create(:application_type,
-                           name:                   "/platform/application-type1",
-                           display_name:           "Application Type One",
-                           supported_source_types: ["openshift"])
+                           :name                   => "/platform/application-type1",
+                           :display_name           => "Application Type One",
+                           :supported_source_types => ["openshift"])
 
         app_type2 = create(:application_type,
-                           name:                   "ApplicationType2",
-                           display_name:           "Application Type Two",
-                           supported_source_types: ["openshift"])
+                           :name                   => "ApplicationType2",
+                           :display_name           => "Application Type Two",
+                           :supported_source_types => ["openshift"])
 
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = create(:application, application_type: app_type1, source: source, tenant: tenant)
-        app2 = create(:application, application_type: app_type2, source: source, tenant: tenant)
+        app1 = create(:application, :application_type => app_type1, :source => source, :tenant => tenant)
+        app2 = create(:application, :application_type => app_type2, :source => source, :tenant => tenant)
 
         source.applications = [app1, app2]
 

--- a/spec/requests/api/v3.0/application_authentications_spec.rb
+++ b/spec/requests/api/v3.0/application_authentications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:endpoint)         { create(:endpoint) }
-  let(:authentication)   { create(:authentication, resource: endpoint) }
+  let(:authentication)   { create(:authentication, :resource => endpoint) }
   let(:application)      { create(:application) }
   let(:attributes)       { {"application_id" => application.id.to_s, "authentication_id" => authentication.id.to_s } }
   let(:collection_path)  { "/api/v3.0/application_authentications" }

--- a/spec/requests/api/v3.0/application_authentications_spec.rb
+++ b/spec/requests/api/v3.0/application_authentications_spec.rb
@@ -8,12 +8,9 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
   end
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
-  let(:source_type)      { SourceType.create!(:name => "my-source-type", :product_name => "My Source Type", :vendor => "ACME") }
-  let(:source)           { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "my-source") }
-  let(:application_type) { ApplicationType.create!(:name => "my-app", :supported_source_types => ["my-source-type"]) }
-  let(:endpoint)         { Endpoint.create!(:source => source, :tenant => tenant) }
-  let(:authentication)   { Authentication.create!(:tenant => tenant, :resource => endpoint) }
-  let(:application)      { Application.create!(:application_type => application_type, :source => source, :tenant => tenant) }
+  let(:endpoint)         { create(:endpoint) }
+  let(:authentication)   { create(:authentication, resource: endpoint) }
+  let(:application)      { create(:application) }
   let(:attributes)       { {"application_id" => application.id.to_s, "authentication_id" => authentication.id.to_s } }
   let(:collection_path)  { "/api/v3.0/application_authentications" }
   let(:payload) do
@@ -35,7 +32,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
       end
 
       it "success: non-empty collection" do
-        ApplicationAuthentication.create!(attributes.merge(:tenant => tenant))
+        create(:application_authentication, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -86,7 +83,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = ApplicationAuthentication.create!(attributes.merge(:tenant => tenant))
+        instance = create(:application_authentication, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -97,7 +94,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
       end
 
       it "failure: with an invalid id" do
-        instance = ApplicationAuthentication.create!(attributes.merge(:tenant => tenant))
+        instance = create(:application_authentication, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -111,7 +108,7 @@ RSpec.describe("v3.0 - ApplicationAuthentications") do
 
     context "delete" do
       it "success: with a valid paylod" do
-        record = ApplicationAuthentication.create!(payload)
+        record = create(:application_authentication, payload)
 
         expect(Sources::Api::Events).to receive(:raise_event).once
         delete(instance_path(record.id), :headers => headers)

--- a/spec/requests/api/v3.0/application_types_spec.rb
+++ b/spec/requests/api/v3.0/application_types_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe("v3.0 - ApplicationTypes") do
       end
 
       it "success: non-empty collection" do
-        ApplicationType.create!(attributes)
+        create(:application_type, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -36,7 +36,7 @@ RSpec.describe("v3.0 - ApplicationTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = ApplicationType.create!(attributes)
+        instance = create(:application_type, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -47,7 +47,7 @@ RSpec.describe("v3.0 - ApplicationTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = ApplicationType.create!(attributes)
+        instance = create(:application_type, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -74,7 +74,7 @@ RSpec.describe("v3.0 - ApplicationTypes") do
 
         context "get" do
           it "success: with a valid id" do
-            instance = ApplicationType.create!(attributes)
+            instance = create(:application_type, attributes)
 
             get(subcollection_path(instance.id), :headers => headers)
 
@@ -85,7 +85,7 @@ RSpec.describe("v3.0 - ApplicationTypes") do
           end
 
           it "failure: with an invalid id" do
-            instance   = ApplicationType.create!(attributes)
+            instance   = create(:application_type, attributes)
             missing_id = (instance.id * 1000)
             expect(ApplicationType.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v3.0/applications_spec.rb
+++ b/spec/requests/api/v3.0/applications_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe("v3.0 - Applications") do
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path)  { "/api/v3.0/applications" }
-  let(:source)           { create(:source, tenant: tenant) }
+  let(:source)           { create(:source, :tenant => tenant) }
   let(:application_type) { create(:application_type) }
   let(:payload) do
     {

--- a/spec/requests/api/v3.0/applications_spec.rb
+++ b/spec/requests/api/v3.0/applications_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe("v3.0 - Applications") do
 
   let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path)  { "/api/v3.0/applications" }
-  let(:source)           { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "my-source") }
-  let(:source_type)      { SourceType.create!(:name => "my-source-type", :product_name => "My Source Type", :vendor => "ACME") }
-  let(:application_type) { ApplicationType.create!("name" => "my-application", :supported_source_types => ["my-source-type"]) }
+  let(:source)           { create(:source, tenant: tenant) }
+  let(:application_type) { create(:application_type) }
   let(:payload) do
     {
       "source_id" => source.id.to_s,
@@ -31,7 +30,7 @@ RSpec.describe("v3.0 - Applications") do
       end
 
       it "success: non-empty collection" do
-        Application.create!(payload.merge(:tenant => tenant))
+        create(:application, payload.merge(:tenant => tenant))
 
         get(collection_path, :headers => headers)
 
@@ -83,7 +82,7 @@ RSpec.describe("v3.0 - Applications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -94,7 +93,7 @@ RSpec.describe("v3.0 - Applications") do
       end
 
       it "failure: with an invalid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -106,7 +105,7 @@ RSpec.describe("v3.0 - Applications") do
     end
 
     context "patch" do
-      let(:instance) { Application.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:application, payload.merge(:tenant => tenant)) }
       it "success: with a valid id" do
         new_attributes = {"availability_status" => "available"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -145,7 +144,7 @@ RSpec.describe("v3.0 - Applications") do
 
     context "delete" do
       it "success: with a valid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
 
         expect(Sources::Api::Events).to receive(:raise_event).once
         delete(instance_path(instance.id), :headers => headers)
@@ -165,7 +164,7 @@ RSpec.describe("v3.0 - Applications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
 
         get(subcollection_path(instance.id, "authentications"), :headers => headers)
 
@@ -176,7 +175,7 @@ RSpec.describe("v3.0 - Applications") do
       end
 
       it "failure: with an invalid id" do
-        instance = Application.create!(payload.merge(:tenant => tenant))
+        instance = create(:application, payload.merge(:tenant => tenant))
         missing_id = (instance.id * 1000)
         expect(Application.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v3.0/authentications_spec.rb
+++ b/spec/requests/api/v3.0/authentications_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe("v3.0 - Authentications") do
       end
 
       it "success: non-empty collection" do
-        Authentication.create!(payload.merge(:tenant => tenant))
+        create(:authentication, payload.merge(:tenant => tenant))
 
         get(collection_path, :headers => headers)
 
@@ -106,7 +106,7 @@ RSpec.describe("v3.0 - Authentications") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Authentication.create!(payload.merge(:tenant => tenant))
+        instance = create(:authentication, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -117,7 +117,7 @@ RSpec.describe("v3.0 - Authentications") do
       end
 
       it "failure: with an invalid id" do
-        instance = Authentication.create!(payload.merge(:tenant => tenant))
+        instance = create(:authentication, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -129,7 +129,7 @@ RSpec.describe("v3.0 - Authentications") do
     end
 
     context "patch" do
-      let(:instance) { Authentication.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:authentication, payload.merge(:tenant => tenant)) }
       it "success: with a valid id" do
         new_attributes = {"name" => "new name"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -164,7 +164,7 @@ RSpec.describe("v3.0 - Authentications") do
     end
 
     context "delete" do
-      let(:instance) { Authentication.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:authentication, payload.merge(:tenant => tenant)) }
 
       it "success: with a valid id" do
         expect(Sources::Api::Events).to receive(:raise_event).once

--- a/spec/requests/api/v3.0/endpoints_spec.rb
+++ b/spec/requests/api/v3.0/endpoints_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe("v3.0 - Endpoints") do
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path) { "/api/v3.0/endpoints" }
-  let(:source)          { Source.create!(:source_type => source_type, :tenant => tenant, :uid => SecureRandom.uuid, :name => "test_source") }
-  let(:source_type)     { SourceType.create!(:name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat") }
+  let(:source)          { create(:source, tenant: tenant) }
 
   let(:payload) do
     {
@@ -39,7 +38,7 @@ RSpec.describe("v3.0 - Endpoints") do
       end
 
       it "success: non-empty collection" do
-        Endpoint.create!(payload.merge(:tenant => tenant))
+        create(:endpoint, payload.merge(:tenant => tenant))
 
         get(collection_path, :headers => headers)
 
@@ -91,7 +90,7 @@ RSpec.describe("v3.0 - Endpoints") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Endpoint.create!(payload.merge(:tenant => tenant))
+        instance = create(:endpoint, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -102,7 +101,7 @@ RSpec.describe("v3.0 - Endpoints") do
       end
 
       it "failure: with an invalid id" do
-        instance = Endpoint.create!(payload.merge(:tenant => tenant))
+        instance = create(:endpoint, payload.merge(:tenant => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -114,7 +113,7 @@ RSpec.describe("v3.0 - Endpoints") do
     end
 
     context "patch" do
-      let(:instance) { Endpoint.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:endpoint, payload.merge(:tenant => tenant)) }
       it "success: with a valid id" do
         new_attributes = {"host" => "example.org"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -152,7 +151,7 @@ RSpec.describe("v3.0 - Endpoints") do
     end
 
     context "delete" do
-      let(:instance) { Endpoint.create!(payload.merge(:tenant => tenant)) }
+      let(:instance) { create(:endpoint, payload.merge(:tenant => tenant)) }
 
       it "success: with a valid id" do
         expect(Sources::Api::Events).to receive(:raise_event).once
@@ -171,7 +170,7 @@ RSpec.describe("v3.0 - Endpoints") do
             "resource_type" => "Tenant",
             "resource_id"   => tenant.id.to_s
           }
-        authentication = Authentication.create!(authentication_payload.merge(:tenant => tenant, :resource => instance))
+        authentication = create(:authentication, authentication_payload.merge(:tenant => tenant, :resource => instance))
 
         expect(Sources::Api::Events).to receive(:raise_event).twice
         delete(instance_path(instance.id), :headers => headers)

--- a/spec/requests/api/v3.0/endpoints_spec.rb
+++ b/spec/requests/api/v3.0/endpoints_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe("v3.0 - Endpoints") do
 
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:collection_path) { "/api/v3.0/endpoints" }
-  let(:source)          { create(:source, tenant: tenant) }
+  let(:source)          { create(:source, :tenant => tenant) }
 
   let(:payload) do
     {

--- a/spec/requests/api/v3.0/endpoints_spec.rb
+++ b/spec/requests/api/v3.0/endpoints_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe("v3.0 - Endpoints") do
             "resource_type" => "Tenant",
             "resource_id"   => tenant.id.to_s
           }
-        authentication = create(:authentication, authentication_payload.merge(:tenant => tenant, :resource => instance))
+        create(:authentication, authentication_payload.merge(:tenant => tenant, :resource => instance))
 
         expect(Sources::Api::Events).to receive(:raise_event).twice
         delete(instance_path(instance.id), :headers => headers)

--- a/spec/requests/api/v3.0/filter_spec.rb
+++ b/spec/requests/api/v3.0/filter_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe("Sources Filtering") do
   let(:headers)           { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:api_version)       { "v3.0" }
   let(:source_collection) { "/api/#{api_version}/sources" }
-  let(:source_type)       { SourceType.create!(:name => "SampleSourceType", :vendor => "Sample Vendor", :product_name => "Sample Product Name") }
 
   def create_source(source_name, opt_params = {})
-    Source.create!({:name => source_name, :source_type_id => source_type.id, :tenant => tenant}.merge(opt_params))
+    create(:source, {:name => source_name}.merge(opt_params))
   end
 
   def expect_success(query, *results)
@@ -55,8 +54,8 @@ RSpec.describe("Sources Filtering") do
 
   context "sorted results via sort_by" do
     before do
-      Source.create!(:name => "sort_by_source_a", :source_type => source_type, :tenant => tenant)
-      Source.create!(:name => "sort_by_source_b", :source_type => source_type, :tenant => tenant)
+      create(:source, name: "sort_by_source_a")
+      create(:source, name: "sort_by_source_b")
     end
 
     it "available for sources with default order" do

--- a/spec/requests/api/v3.0/filter_spec.rb
+++ b/spec/requests/api/v3.0/filter_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe("Sources Filtering") do
 
   context "sorted results via sort_by" do
     before do
-      create(:source, name: "sort_by_source_a")
-      create(:source, name: "sort_by_source_b")
+      create(:source, :name => "sort_by_source_a")
+      create(:source, :name => "sort_by_source_b")
     end
 
     it "available for sources with default order" do

--- a/spec/requests/api/v3.0/graphql_controller_spec.rb
+++ b/spec/requests/api/v3.0/graphql_controller_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe("v3.0 - GraphQL") do
 
   let!(:graphql_endpoint) { "/api/v3.0/graphql" }
   let!(:headers)          { { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity } }
-  let!(:source_typeR) { create(:source_type, name: "rhev_sample", product_name: "RedHat Virtualization", vendor: "redhat") }
-  let!(:source_typeV) { create(:source_type, name: "vmware_sample", product_name: "VmWare vCenter", vendor: "vmware") }
-  let!(:source_typeO) { create(:source_type, name: "openstack_sample", product_name: "OpenStack", vendor: "redhat") }
+  let!(:source_typeR) { create(:source_type, :name => "rhev_sample", :product_name => "RedHat Virtualization", :vendor => "redhat") }
+  let!(:source_typeV) { create(:source_type, :name => "vmware_sample", :product_name => "VmWare vCenter", :vendor => "vmware") }
+  let!(:source_typeO) { create(:source_type, :name => "openstack_sample", :product_name => "OpenStack", :vendor => "redhat") }
 
   context "support result sorting using the v2 interface" do
     before { stub_const("ENV", "BYPASS_TENANCY" => nil) }

--- a/spec/requests/api/v3.0/graphql_controller_spec.rb
+++ b/spec/requests/api/v3.0/graphql_controller_spec.rb
@@ -3,9 +3,9 @@ RSpec.describe("v3.0 - GraphQL") do
 
   let!(:graphql_endpoint) { "/api/v3.0/graphql" }
   let!(:headers)          { { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity } }
-  let!(:source_typeR) { SourceType.create(:name => "rhev_sample", :product_name => "RedHat Virtualization", :vendor => "redhat") }
-  let!(:source_typeV) { SourceType.create(:name => "vmware_sample", :product_name => "VmWare vCenter", :vendor => "vmware") }
-  let!(:source_typeO) { SourceType.create(:name => "openstack_sample", :product_name => "OpenStack", :vendor => "redhat") }
+  let!(:source_typeR) { create(:source_type, name: "rhev_sample", product_name: "RedHat Virtualization", vendor: "redhat") }
+  let!(:source_typeV) { create(:source_type, name: "vmware_sample", product_name: "VmWare vCenter", vendor: "vmware") }
+  let!(:source_typeO) { create(:source_type, name: "openstack_sample", product_name: "OpenStack", vendor: "redhat") }
 
   context "support result sorting using the v2 interface" do
     before { stub_const("ENV", "BYPASS_TENANCY" => nil) }

--- a/spec/requests/api/v3.0/source_types_spec.rb
+++ b/spec/requests/api/v3.0/source_types_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe("v3.0 - SourceTypes") do
       end
 
       it "success: non-empty collection" do
-        SourceType.create!(attributes)
+        create(:source_type, attributes)
 
         get(collection_path, :headers => headers)
 
@@ -49,7 +49,7 @@ RSpec.describe("v3.0 - SourceTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -60,7 +60,7 @@ RSpec.describe("v3.0 - SourceTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -79,7 +79,7 @@ RSpec.describe("v3.0 - SourceTypes") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
 
         get(subcollection_path(instance.id, "sources"), :headers => headers)
 
@@ -90,7 +90,7 @@ RSpec.describe("v3.0 - SourceTypes") do
       end
 
       it "failure: with an invalid id" do
-        instance = SourceType.create!(attributes)
+        instance = create(:source_type, attributes)
         missing_id = (instance.id * 1000)
         expect(Source.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v3.0 - Sources") do
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v3.0/sources" }
-  let(:source_type)     { SourceType.create!(:name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
+  let(:source_type)     { create(:source_type, name: "SourceType", vendor: "Some Vendor", product_name: "Product Name") }
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
@@ -26,7 +26,7 @@ RSpec.describe("v3.0 - Sources") do
         end
 
         it "success: non-empty collection" do
-          Source.create!(attributes.merge("tenant" => tenant))
+          create(:source, attributes.merge("tenant" => tenant))
 
           get(collection_path, :headers => headers)
 
@@ -50,7 +50,7 @@ RSpec.describe("v3.0 - Sources") do
         end
 
         it "success: non-empty collection" do
-          Source.create!(attributes.merge("tenant" => tenant))
+          create(:source, attributes.merge("tenant" => tenant))
 
           get(collection_path, :headers => headers)
 
@@ -184,7 +184,7 @@ RSpec.describe("v3.0 - Sources") do
 
     context "get" do
       it "success: with a valid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
 
         get(instance_path(instance.id), :headers => headers)
 
@@ -195,7 +195,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "failure: with an invalid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
 
         get(instance_path(instance.id * 1000), :headers => headers)
 
@@ -208,7 +208,7 @@ RSpec.describe("v3.0 - Sources") do
 
     context "patch" do
       it "success: with a valid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -222,7 +222,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "failure: with a null value" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => nil}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -236,7 +236,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "failure: with an invalid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name"}
 
         patch(instance_path(instance.id * 1000), :params => new_attributes.to_json, :headers => headers)
@@ -248,7 +248,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "failure: with extra parameters" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"aaaaa" => "bbbbb"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -260,7 +260,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "failure: with read-only parameters" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"uid" => "xxxxx"}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -328,7 +328,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "rejects read_only attributes" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
         new_attributes = {"name" => "new name", "created_at" => Time.now.utc}
 
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
@@ -342,7 +342,7 @@ RSpec.describe("v3.0 - Sources") do
 
     context "delete" do
       it "success: with a valid id" do
-        instance = Source.create!(attributes.merge("tenant" => tenant))
+        instance = create(:source, attributes.merge("tenant" => tenant))
 
         expect(Sources::Api::Events).to receive(:raise_event).once
         delete(instance_path(instance.id), :headers => headers)
@@ -354,9 +354,9 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with associated applications" do
-        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        instance    = Source.create!(attributes.merge("tenant" => tenant))
+        instance    = create(:source, attributes.merge("tenant" => tenant))
 
         app_type1 = ApplicationType.create(:name         => "/platform/application-type1",
                                            :display_name => "Application Type One",
@@ -383,7 +383,7 @@ RSpec.describe("v3.0 - Sources") do
           "certificate_authority" => "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----",
         }
 
-        Endpoint.create!(tenant_payload.merge(:tenant => tenant, :source => instance))
+        create(:endpoint, tenant_payload.merge(:tenant => tenant, :source => instance))
 
         expect(Sources::Api::Events).to receive(:raise_event).exactly(4).times
         delete(instance_path(instance.id), :headers => headers)
@@ -432,9 +432,9 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with valid openshift source" do
-        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => openshift_topic,
@@ -455,9 +455,9 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with valid amazon source" do
-        source_type = SourceType.create!(:name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
+        source_type = create(:source_type, name: "amazon", vendor: "Amazon", product_name: "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => amazon_topic,
@@ -478,9 +478,9 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with a source-type that topology doesn't support" do
-        source_type = SourceType.create!(:name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
+        source_type = create(:source_type, name: "vsphere", vendor: "VMware", product_name: "VMware vSphere")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
         expect(messaging_client).not_to receive(:publish_topic)
         post(check_availability_path(source.id), :headers => headers)
@@ -492,23 +492,25 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with valid openshift source querying associated applications" do
-        source_type = SourceType.create!(:name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
-        source      = Source.create!(attributes.merge("tenant" => tenant))
+        source      = create(:source, attributes.merge("tenant" => tenant))
 
-        app_type1 = ApplicationType.create(:name         => "/platform/application-type1",
-                                           :display_name => "Application Type One",
-                                           :supported_source_types => ["openshift"])
+        app_type1 = create(:application_type,
+                           name:                   "/platform/application-type1",
+                           display_name:           "Application Type One",
+                           supported_source_types: ["openshift"])
 
-        app_type2 = ApplicationType.create(:name         => "ApplicationType2",
-                                           :display_name => "Application Type Two",
-                                           :supported_source_types => ["openshift"])
+        app_type2 = create(:application_type,
+                           name:                   "ApplicationType2",
+                           display_name:           "Application Type Two",
+                           supported_source_types: ["openshift"])
 
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = Application.create(:application_type => app_type1, :source => source, :tenant => tenant)
-        app2 = Application.create(:application_type => app_type2, :source => source, :tenant => tenant)
+        app1 = create(:application, application_type: app_type1, source: source, tenant: tenant)
+        app2 = create(:application, application_type: app_type2, source: source, tenant: tenant)
 
         source.applications = [app1, app2]
 
@@ -577,7 +579,7 @@ RSpec.describe("v3.0 - Sources") do
 
         context "get" do
           it "success: with a valid id" do
-            instance = Source.create!(attributes.merge("tenant" => tenant))
+            instance = create(:source, attributes.merge("tenant" => tenant))
 
             get(subcollection_path(instance.id), :headers => headers)
 
@@ -588,7 +590,7 @@ RSpec.describe("v3.0 - Sources") do
           end
 
           it "failure: with an invalid id" do
-            instance = Source.create!(attributes.merge("tenant" => tenant))
+            instance = create(:source, attributes.merge("tenant" => tenant))
             missing_id = (instance.id * 1000)
             expect(Source.exists?(missing_id)).to eq(false)
 

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -371,8 +371,8 @@ RSpec.describe("v3.0 - Sources") do
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = create(:application, :application_type => app_type1, :source => instance, :tenant => tenant)
-        app2 = create(:application, :application_type => app_type2, :source => instance, :tenant => tenant)
+        create(:application, :application_type => app_type1, :source => instance, :tenant => tenant)
+        create(:application, :application_type => app_type2, :source => instance, :tenant => tenant)
 
         tenant_payload = {
           "host"                  => "example.com",

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe("v3.0 - Sources") do
   let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v3.0/sources" }
-  let(:source_type)     { create(:source_type, name: "SourceType", vendor: "Some Vendor", product_name: "Product Name") }
+  let(:source_type)     { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
   let(:client)          { instance_double("ManageIQ::Messaging::Client") }
   before do
     allow(client).to receive(:publish_topic)
@@ -354,23 +354,25 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with associated applications" do
-        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         instance    = create(:source, attributes.merge("tenant" => tenant))
 
-        app_type1 = ApplicationType.create(:name         => "/platform/application-type1",
-                                           :display_name => "Application Type One",
-                                           :supported_source_types => ["openshift"])
+        app_type1 = create(:application_type,
+                           :name                   => "/platform/application-type1",
+                           :display_name           => "Application Type One",
+                           :supported_source_types => ["openshift"])
 
-        app_type2 = ApplicationType.create(:name         => "ApplicationType2",
-                                           :display_name => "Application Type Two",
-                                           :supported_source_types => ["openshift"])
+        app_type2 = create(:application_type,
+                           :name                   => "ApplicationType2",
+                           :display_name           => "Application Type Two",
+                           :supported_source_types => ["openshift"])
 
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = Application.create(:application_type => app_type1, :source => instance, :tenant => tenant)
-        app2 = Application.create(:application_type => app_type2, :source => instance, :tenant => tenant)
+        app1 = create(:application, :application_type => app_type1, :source => instance, :tenant => tenant)
+        app2 = create(:application, :application_type => app_type2, :source => instance, :tenant => tenant)
 
         tenant_payload = {
           "host"                  => "example.com",
@@ -432,7 +434,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with valid openshift source" do
-        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -455,7 +457,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with valid amazon source" do
-        source_type = create(:source_type, name: "amazon", vendor: "Amazon", product_name: "Amazon Web Services")
+        source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -478,7 +480,7 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with a source-type that topology doesn't support" do
-        source_type = create(:source_type, name: "vsphere", vendor: "VMware", product_name: "VMware vSphere")
+        source_type = create(:source_type, :name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
 
@@ -492,25 +494,25 @@ RSpec.describe("v3.0 - Sources") do
       end
 
       it "success: with valid openshift source querying associated applications" do
-        source_type = create(:source_type, name: "openshift", vendor: "RedHat", product_name: "OpenShift")
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
 
         app_type1 = create(:application_type,
-                           name:                   "/platform/application-type1",
-                           display_name:           "Application Type One",
-                           supported_source_types: ["openshift"])
+                           :name                   => "/platform/application-type1",
+                           :display_name           => "Application Type One",
+                           :supported_source_types => ["openshift"])
 
         app_type2 = create(:application_type,
-                           name:                   "ApplicationType2",
-                           display_name:           "Application Type Two",
-                           supported_source_types: ["openshift"])
+                           :name                   => "ApplicationType2",
+                           :display_name           => "Application Type Two",
+                           :supported_source_types => ["openshift"])
 
         app_type1_url = "http://app1.example.com:8001/availability_check"
         app_type2_url = "http://app2.example.com:8002/availability_check"
 
-        app1 = create(:application, application_type: app_type1, source: source, tenant: tenant)
-        app2 = create(:application, application_type: app_type2, source: source, tenant: tenant)
+        app1 = create(:application, :application_type => app_type1, :source => source, :tenant => tenant)
+        app2 = create(:application, :application_type => app_type2, :source => source, :tenant => tenant)
 
         source.applications = [app1, app2]
 

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -4,7 +4,7 @@ module Spec
       extend ActiveSupport::Concern
 
       included do
-        let!(:tenant)           { Tenant.create!(:name => "default", :external_tenant => external_tenant) }
+        let!(:tenant)           { create(:tenant, name: "default", external_tenant: external_tenant) }
         let!(:external_tenant)  { rand(1000).to_s }
         let!(:unknown_tenant)   { rand(1000).to_s }
         let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}}.to_json) }

--- a/spec/support/tenant_identity.rb
+++ b/spec/support/tenant_identity.rb
@@ -4,7 +4,7 @@ module Spec
       extend ActiveSupport::Concern
 
       included do
-        let!(:tenant)           { create(:tenant, name: "default", external_tenant: external_tenant) }
+        let!(:tenant)           { create(:tenant, :name => "default", :external_tenant => external_tenant) }
         let!(:external_tenant)  { rand(1000).to_s }
         let!(:unknown_tenant)   { rand(1000).to_s }
         let!(:identity)         { Base64.encode64({'identity' => { 'account_number' => external_tenant, 'user' => { 'is_org_admin' => true }}}.to_json) }


### PR DESCRIPTION
Converted tests to use FactoryBot.

Some more work can probably be done to clean up the TenantIdentity mixin, or eliminate the need for it completely.