### PR TITLE
Retry in 30 seconds if remote Kafka cluster is not connectable

### DIFF
--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -27,6 +27,12 @@ class AvailabilityStatusListener
         process_event(event)
       end
     end
+  rescue Kafka::ConnectionError => e
+    Rails.logger.error("Cannot connect to Kafka cluster #{messaging_client_options[:host]}")
+    unless messaging_client_options[:host] == 'localhost'
+      sleep 30 # Remote Kafka may be down. Try again later
+      retry
+    end
   rescue => e
     Rails.logger.error(["Something is wrong with Kafka client: ", e.message, *e.backtrace].join($RS))
     retry


### PR DESCRIPTION
A problem was exposed at travis build where the Kafka listener is automatically start in a separate thread. Because no Kafka host is configured, the thread restarts with an infinite loop. The enhancement is to stop the listener if local Kafka is not connectable. Another practical issue is the remote Kafka may be temporarily down. It makes sense to wait a while before retry.