### PR TITLE
Remove SourceType create operation from v1 of the API

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,7 @@ Rails.application.routes.draw do
       resources :endpoints,         :only => [:create, :destroy, :index, :show, :update] do
         resources :authentications, :only => [:index]
       end
-      resources :source_types,    :only => [:create, :index, :show] do
+      resources :source_types,    :only => [:index, :show] do
         resources :sources, :only => [:index]
       end
       resources :sources,         :only => [:create, :destroy, :index, :show, :update] do

--- a/public/doc/openapi-3-v1.0.json
+++ b/public/doc/openapi-3-v1.0.json
@@ -735,34 +735,6 @@
             }
           }
         }
-      },
-      "post": {
-        "summary": "Create a new SourceType",
-        "operationId": "createSourceType",
-        "description": "Creates a SourceType object",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SourceType"
-              }
-            }
-          },
-          "description": "SourceType attributes to create",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "SourceType creation successful",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SourceType"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/source_types/{id}": {

--- a/spec/requests/api/v1.0/source_types_spec.rb
+++ b/spec/requests/api/v1.0/source_types_spec.rb
@@ -29,44 +29,6 @@ RSpec.describe("v1.0 - SourceTypes") do
         )
       end
     end
-
-    context "post" do
-      let(:client) { instance_double("ManageIQ::Messaging::Client") }
-      before do
-        allow(client).to receive(:publish_topic)
-        allow(Sources::Api::Messaging).to receive(:client).and_return(client)
-      end
-
-      it "success: with valid body" do
-        post(collection_path, :params => attributes.to_json, :headers => headers)
-
-        expect(response).to have_attributes(
-          :status => 201,
-          :location => "http://www.example.com/api/v1.0/source_types/#{response.parsed_body["id"]}",
-          :parsed_body => a_hash_including(attributes)
-        )
-      end
-
-      it "failure: with extra attributes" do
-        post(collection_path, :params => attributes.merge("aaa" => "bbb").to_json, :headers => headers)
-
-        expect(response).to have_attributes(
-          :status => 400,
-          :location => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/SourceType does not define properties: aaa").to_h
-        )
-      end
-
-      it "failure: with an invalid attribute value" do
-        post(collection_path, :params => attributes.merge("name" => 123).to_json, :headers => headers)
-
-        expect(response).to have_attributes(
-          :status      => 400,
-          :location    => nil,
-          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/SourceType/properties/name expected string, but received Integer: 123").to_h
-        )
-      end
-    end
   end
 
   describe("/api/v1.0/source_types/:id") do


### PR DESCRIPTION
This was found to be a bug on the stage environment, users of the v1.0 API were still able to create source types, which should not be allowed.

This change simply removes that route. 