### PR TITLE
Pin CloudWatchLogger to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
+gem 'cloudwatchlogger',     '~> 0.2.1'
 gem 'insights-api-common',  '~> 4.0'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/70

CloudWatchLogger 0.3.0 is not compatible