### PR TITLE
Remove S3 Bucket Name field from wizard summary

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -27,7 +27,7 @@ amazon:
         :initializeOnMount: true
         :initialValue: arn
       - :name: billing_source.data_source.bucket
-        :stepKey: amazon-arn-additional-step
+        :stepKey: cost-management
         :component: text-field
         :label: S3 bucket name
         :isRequired: true


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/TPINVTRY-1075

`stepKey` attribute is used to append a field to a step in the wizard, however S3 Bucket is exclusive to the cost management application, so the step key should indicate it belongs to the app.

This should prevent this value appearing in the no app arn summary details.
