### PR TITLE
Remove unused source types

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -214,14 +214,6 @@ openshift:
           :is: true
   :vendor: Red Hat
   :icon_url: "/apps/frontend-assets/platform-logos/openshift-container-platform.svg"
-openstack:
-  :product_name: Red Hat OpenStack
-  :vendor: Red Hat
-  :icon_url: "/apps/chrome/assets/images/platform-icons/openstack.svg"
-ovirt:
-  :product_name: Red Hat Virtualization
-  :vendor: Red Hat
-  :icon_url: "/apps/chrome/assets/images/platform-icons/ovirt.svg"
 satellite:
   :product_name: Red Hat Satellite
   :vendor: Red Hat
@@ -253,7 +245,3 @@ satellite:
         :initializeOnMount: true
         :initialValue: satellite
   :icon_url: "/apps/frontend-assets/platform-logos/satellite.svg"
-vsphere:
-  :product_name: VMware vSphere
-  :vendor: VMware
-  :icon_url: "/apps/chrome/assets/images/partners-icons/vmware.svg"


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/TPINVTRY-1077

This is a draft PR for discussing how to properly solve this issue. (If it's going to be an issue at all.)

There are basically two options:

1) Remove unused source types from API (**this PR**)

2) Hide unused sources types in the UI

Personally, I would go with the first option as I am trying to make the UI as much consistent to the API as possible. Data should be controlled by the API, not in the UI that just shows them. Hiding them would introduce two additional issues: users won't see sources created from the API and there would have to be a list with hidden types (so more code to keep updated and more code with possible bugs). Also, it doesn't make much sense to have unusable types defined in the API.

What do you think @syncrou ?

cc @beccaglass

TODO:
- [x] migration
   - I am not sure how to migrate these data.
