### PR TITLE
Upgrading the insights-api-common gem to 4.1.4 version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem 'cloudwatchlogger',     '~> 0.2.1'
-gem 'insights-api-common',  '~> 4.0'
+gem 'insights-api-common',  '~> 4.1.4'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"


### PR DESCRIPTION
Upgrading the `insights-api-common` gem to 4.1.4 version that no longer allows redirects from major versions on a POST.

This PR is based on https://issues.redhat.com/browse/RHCLOUD-9585.