### PR TITLE
Skip running rake db:seed when running just the rails server

### DIFF
--- a/docker-assets/run_rails_server
+++ b/docker-assets/run_rails_server
@@ -28,6 +28,4 @@ write_encryption_key
 # Wait for postgres to be ready
 check_svc_status $DATABASE_HOST $DATABASE_PORT
 
-bundle exec rake db:migrate
-bundle exec rake db:seed
-bundle exec rails server
+bundle exec rake db:migrate && bundle exec rails server


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-9736

Basically this PR is pulling out the `rake db:seed` step from the initialization of the rails server - moving it to an `initContainer` in the openshift template. This way the server doesn't take ages to start up. 

(also adding the `&&` to the commands so if a migration fails the whole thing fails)

**DEPENDS ON:**
- [x] https://github.com/RedHatInsights/e2e-deploy/pull/2369