### PR TITLE
Add call out to RBAC for write-access check

### DIFF
--- a/app/policies/default_policy.rb
+++ b/app/policies/default_policy.rb
@@ -30,10 +30,12 @@ class DefaultPolicy
   alias delete? destroy?
 
   def admin?
-    return true unless Insights::API::Common::RBAC::Access.enabled?
+    return true unless Sources::RBAC::Access.enabled?
 
-    user.system.present? || user.user&.org_admin?
+    user.system.present? || user.user&.org_admin? || write_access?
   end
+
+  delegate :write_access?, :to => Sources::RBAC::Access
 
   class Scope
     attr_reader :user, :scope

--- a/lib/sources/rbac/access.rb
+++ b/lib/sources/rbac/access.rb
@@ -1,0 +1,19 @@
+module Sources
+  module RBAC
+    class Access
+      class << self
+        def enabled?
+          Insights::API::Common::RBAC::Access.enabled?
+        end
+
+        def write_access?
+          access.accessible?("*", "*") # sources:*:* is the only permission as of now.
+        end
+
+        def access
+          @access ||= Insights::API::Common::RBAC::Access.new.process
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -189,19 +189,6 @@ RSpec.describe ApplicationController, :type => :request do
       expect(response.status).to eq(200)
     end
 
-    it "rejects PATCH request with tenancy enforcement and user not as org_admin" do
-      headers = {
-        "CONTENT_TYPE"  => "application/json",
-        "x-rh-identity" => Base64.encode64(
-          { "identity" => { "account_number" => external_tenant, "user" => { "is_org_admin" => false }}}.to_json
-        )
-      }
-
-      patch("/api/v1.0/sources/#{source.id}", :params => { "name" => "updated_name" }.to_json, :headers => headers)
-
-      expect(response.status).to eq(403)
-    end
-
     it "accepts HEAD request with tenancy enforcement and user not as org_admin" do
       headers = {
         "CONTENT_TYPE"  => "application/json",

--- a/spec/lib/sources/rbac/access_spec.rb
+++ b/spec/lib/sources/rbac/access_spec.rb
@@ -1,0 +1,27 @@
+describe Sources::RBAC::Access do
+  context "when rbac is enabled" do
+    let(:rbac_access) { instance_double(Insights::API::Common::RBAC::Access) }
+
+    before do
+      allow(described_class).to receive(:enabled?).and_return(true)
+      allow(described_class).to receive(:access).and_return(rbac_access)
+      allow(rbac_access).to receive(:accessible?).with("*", "*").and_return(accessible)
+    end
+
+    context "when the user has write permissions" do
+      let(:accessible) { true }
+
+      it "it allows the user access to the object" do
+        expect(described_class.write_access?).to be_truthy
+      end
+    end
+
+    context "when the user does not have write permissions" do
+      let(:accessible) { false }
+
+      it "does not allow the user access to the object" do
+        expect(described_class.write_access?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/requests/api/rbac_spec.rb
+++ b/spec/requests/api/rbac_spec.rb
@@ -1,0 +1,61 @@
+describe("RBAC requests") do
+  include ::Spec::Support::TenantIdentity
+  let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => non_org_admin_identity} }
+  let(:source_type) { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
+  let(:attributes) { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
+
+  before do
+    allow(Sources::Api::Events).to receive(:raise_event).and_return(true)
+  end
+
+  context "when making requests that do not require rbac" do
+    it "does not query rbac" do
+      expect(Sources::RBAC::Access).not_to receive(:enabled?)
+
+      get("/api/v3.0/sources", :headers => headers)
+      expect(response.status).to eq 200
+    end
+  end
+
+  context "when making a rbac enforced request" do
+    let(:rbac_access) { instance_double(Insights::API::Common::RBAC::Access) }
+
+    before do
+      allow(Sources::RBAC::Access).to receive(:enabled?).and_return(true)
+    end
+
+    context "when the user has write access" do
+      before do
+        allow(Sources::RBAC::Access).to receive(:write_access?).and_return(true)
+      end
+
+      it "allows the operation" do
+        expect(Sources::RBAC::Access).to receive(:enabled?).once
+        post("/api/v3.0/sources", :params => attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.0/sources/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(attributes)
+        )
+      end
+    end
+
+    context "when the user does not have write access" do
+      before do
+        allow(Sources::RBAC::Access).to receive(:write_access?).and_return(false)
+      end
+
+      it "denies the operation" do
+        expect(Sources::RBAC::Access).to receive(:enabled?).once
+
+        post("/api/v3.0/sources", :params => attributes.to_json, :headers => headers)
+        expect(response).to have_attributes(
+          :status      => 403,
+          :location    => nil,
+          :parsed_body => {"errors"=>[{"status" => "403", "detail" => "You are not authorized to create this source"}]}
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-9964

- [x] Built off of #267 so that one needs to go in first.

Pretty self-explanatory, this just adds in the call out to the RBAC service for authorization when doing anything that requires write access (admin-only for now). 

The only permission as of right now is `sources:*:*` which we will potentially expand later. 
