### PR TITLE
Publishing Kafka event ApplicationAuthentication.destroy

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -5,7 +5,7 @@ class Application < ApplicationRecord
   belongs_to :source
   belongs_to :application_type
 
-  has_many :application_authentications
+  has_many :application_authentications, :dependent => :destroy
   has_many :authentications, :through => :application_authentications
 
   attribute :availability_status, :string

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -6,7 +6,7 @@ class Authentication < ApplicationRecord
 
   belongs_to :resource, :polymorphic => true
 
-  has_many :application_authentications
+  has_many :application_authentications, :dependent => :destroy
   has_many :applications, :through => :application_authentications
 
   attribute :availability_status, :string


### PR DESCRIPTION
After destroying of Application or Authentication, if ApplicationAuthentication relation exists, kafka event `ApplicationAuthentication.destroy` has to be raised as a cascade delete operation

---

[RHCLOUD-10263](https://issues.redhat.com/browse/RHCLOUD-10263)