### PR TITLE
Memoize `Sources::Api::Messaging.client` instead of using thread-local storage

### DIFF
--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -6,14 +6,12 @@ module Sources
       def self.client
         require "manageiq-messaging"
 
-        Thread.current[:messaging_client] ||= begin
-          ManageIQ::Messaging::Client.open(
-            :protocol => :Kafka,
-            :host     => ENV["QUEUE_HOST"] || "localhost",
-            :port     => ENV["QUEUE_PORT"] || "9092",
-            :encoding => "json"
-          )
-        end
+        @client ||= ManageIQ::Messaging::Client.open(
+          :protocol => :Kafka,
+          :host     => ENV["QUEUE_HOST"] || "localhost",
+          :port     => ENV["QUEUE_PORT"] || "9092",
+          :encoding => "json"
+        )
       end
 
       cache_with_timeout(:topics) do


### PR DESCRIPTION
Same change as on topo + ingress, memoizing the api client so we don't instantiate (and then never close) a bunch of messaging clients.
