### PR TITLE
Remove check for whether a topic exists when checking Source#availability_status

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -26,7 +26,7 @@ module Api
 
         logger.info("Initiating Source#availability_check [#{{"source_id" => source.id, "topic" => topic}}]")
 
-        if Sources::Api::Messaging.topics.include?(topic)
+        begin
           logger.debug("Publishing message for Source#availability_check [#{{"source_id" => source.id, "topic" => topic}}]")
 
           Sources::Api::Messaging.client.publish_topic(
@@ -43,8 +43,8 @@ module Api
           )
 
           logger.debug("Publishing message for Source#availability_check [#{{"source_id" => source.id, "topic" => topic}}]...Complete")
-        else
-          logger.error("Not publishing message to non-existing topic: Source#availability_check [#{{"source_id" => source.id, "topic" => topic}}]")
+        rescue e
+          logger.error("Hit error attempting to publish [#{{"source_id" => source.id, "topic" => topic}}] during Source#availability_check: #{e.message}")
         end
 
         check_application_availability(source)

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -13,10 +13,6 @@ module Sources
           :encoding => "json"
         )
       end
-
-      cache_with_timeout(:topics) do
-        client.topics || []
-      end
     end
   end
 end

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -363,12 +363,6 @@ RSpec.describe("v1.0 - Sources") do
     before do
       allow(messaging_client).to receive(:publish_topic)
       allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
-      allow(Sources::Api::Messaging).to receive(:topics).and_return(
-        [
-          "platform.topological-inventory.operations-amazon",
-          "platform.topological-inventory.operations-openshift",
-        ]
-      )
     end
 
     context "post" do
@@ -432,7 +426,6 @@ RSpec.describe("v1.0 - Sources") do
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
 
-        expect(messaging_client).not_to receive(:publish_topic)
         post(check_availability_path(source.id), :headers => headers)
 
         expect(response).to have_attributes(

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -353,12 +353,6 @@ RSpec.describe("v2.0 - Sources") do
     before do
       allow(messaging_client).to receive(:publish_topic)
       allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
-      allow(Sources::Api::Messaging).to receive(:topics).and_return(
-        [
-          "platform.topological-inventory.operations-amazon",
-          "platform.topological-inventory.operations-openshift",
-        ]
-      )
     end
 
     context "post" do
@@ -422,7 +416,6 @@ RSpec.describe("v2.0 - Sources") do
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
 
-        expect(messaging_client).not_to receive(:publish_topic)
         post(check_availability_path(source.id), :headers => headers)
 
         expect(response).to have_attributes(

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -411,12 +411,6 @@ RSpec.describe("v3.0 - Sources") do
     before do
       allow(messaging_client).to receive(:publish_topic)
       allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
-      allow(Sources::Api::Messaging).to receive(:topics).and_return(
-        [
-          "platform.topological-inventory.operations-amazon",
-          "platform.topological-inventory.operations-openshift",
-        ]
-      )
     end
 
     context "post" do
@@ -480,7 +474,6 @@ RSpec.describe("v3.0 - Sources") do
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
 
-        expect(messaging_client).not_to receive(:publish_topic)
         post(check_availability_path(source.id), :headers => headers)
 
         expect(response).to have_attributes(


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-10747

It seems we are running into this issue a lot where the message producers will "forget" that a topic exists, and proceed to not produce the availability status messages anymore, seemingly happens in random intervals but the logs are filled with messages like this:
```json
{
  "@timestamp": "2020-11-16T16:04:31.059618 ",
  "hostname": "sources-api-774b8d79cc-6m2zs",
  "pid": 32,
  "tid": "2afa089bbc0c",
  "level": "err",
  "message": "Not publishing message to non-existing topic: Source#availability_check [{\"source_id\"=>1307, \"topic\"=>\"platform.topological-inventory.operations-azure\"}]",
  "request_id": "a240ffd873bc45fea2e6665e8b925552"
}
```

even though the topic definitely exists.

---

This PR is one possible solution - rather than checking if a topic exists and not producing, lets just try and produce every time and just rescue/log. 
Open to other suggestions as well, another solution would be to potentially instantiate a new producer every time and just close it properly? But I'm not sure what the cost would be as far as resources go for that since opening up a FFI connection isn't cheap. 
