### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sources API
 
-[![Build Status](https://travis-ci.org/RedHatInsights/sources-api.svg?branch=master)](https://travis-ci.org/RedHatInsights/sources-api)
+[![Build Status](https://travis-ci.com/RedHatInsights/sources-api.svg?branch=master)](https://travis-ci.com/RedHatInsights/sources-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/bc0595445f017018ffbc/maintainability)](https://codeclimate.com/github/RedHatInsights/sources-api/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/bc0595445f017018ffbc/test_coverage)](https://codeclimate.com/github/RedHatInsights/sources-api/test_coverage)
 [![Security](https://hakiri.io/github/RedHatInsights/sources-api/master.svg)](https://hakiri.io/github/RedHatInsights/sources-api/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on RedHatInsights/topological_inventory-api#334 issue.