### PR TITLE
Remove memoization of rbac access class variable

### DIFF
--- a/lib/sources/rbac/access.rb
+++ b/lib/sources/rbac/access.rb
@@ -11,7 +11,7 @@ module Sources
         end
 
         def access
-          @access ||= Insights::API::Common::RBAC::Access.new.process
+          Insights::API::Common::RBAC::Access.new.process
         end
       end
     end


### PR DESCRIPTION
I think this is the problem we're seeing, since it was a class var and it was memoized the first person who logged in sets the permissions for the rest of the hits. Not ideal. 
