### PR TITLE
Kafka availability_status_listener fix.

### DIFF
--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe AvailabilityStatusListener do
   let(:client)     { double(:client) }
   let(:event_type) { AvailabilityStatusListener::EVENT_AVAILABILITY_STATUS }
-  let(:payload)    { {"resource_type" => resource_type, "resource_id" => resource_id, "status" => status, "error" => reason} }
+  let(:payload)    { {"resource_type" => resource_type, "resource_id" => resource_id, "status" => status, "error" => reason}.to_json }
   let(:status)     { "unavailable" }
   let(:reason)     { "host unreachable" }
   let(:now)        { Time.new(2020).utc }


### PR DESCRIPTION
Kafka availability_status_listener fix.

Based on: https://github.com/RedHatInsights/sources-api/issues/286
Depends on: [ ] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/68

In the pictures bellow you can see the sources-api command line output containing DB update for all realted tables. 

services/ansible-tower-operations.sh :
![Screenshot from 2020-12-07 17-11-41](https://user-images.githubusercontent.com/19405716/101376003-58ca8900-38b0-11eb-8988-272d947e9039.png)
sources-api:
![Screenshot from 2020-12-07 17-11-11](https://user-images.githubusercontent.com/19405716/101376014-5a944c80-38b0-11eb-8c78-985699789cde.png)
DB:
![Screenshot from 2020-12-07 17-12-07](https://user-images.githubusercontent.com/19405716/101376000-57995c00-38b0-11eb-95cd-af90a32c2752.png)

EDIT: 
 - Add missing message type for logging message. 
    - example: Kafka message **availability_status** received with payload....
