### PR TITLE
[WIP]GraphQL provide metadata

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -3,6 +3,10 @@ require "insights/api/common/graphql"
 module Api
   module V1
     class GraphqlController < ApplicationController
+      class << self
+        attr_accessor :limit_and_offset
+      end
+
       def query
         schema_overlay = {
           "^.+$" => {
@@ -19,7 +23,61 @@ module Api
           params[:query],
           :variables => variables
         )
-        render :json => result
+
+        # metadata calculations
+        meta = {"count" => result["data"] ? result["data"]["sources"].size : 0}
+        limit_and_offset = Api::V1::GraphqlController.limit_and_offset || {}
+        limit = limit_and_offset['limit']
+        offset = limit_and_offset['offset']
+        meta["limit"]  = limit  if limit
+        meta["offset"] = offset if offset
+
+        # apply limit and offset for results
+        if meta["count"] > 0
+          result = result["data"]["sources"]
+          if offset && offset <= result.size
+            result = result[offset..-1]
+          elsif offset
+            result = []
+          end
+          result = result[0..limit - 1] if limit
+        end
+
+        render :json => {'meta' => meta, 'data' => result}
+      ensure
+        Api::V1::GraphqlController.limit_and_offset = nil
+      end
+    end
+  end
+end
+
+module GraphQL
+  module Execution
+    class Execute
+      class << self
+        def begin_query(query, _multiplex)
+          unless query.selected_operation.children[0].arguments.empty?
+            remove_offset_and_limit(query)
+          end
+
+          ExecutionFunctions.resolve_root_selection(query)
+        end
+
+        private
+
+        # Remove and save limit/offset for root element inside the query
+        def remove_offset_and_limit(query)
+          limit_and_offset = {}
+          query.selected_operation.children[0].arguments.delete_if do |arg|
+            if arg.name == 'offset' || arg.name == 'limit'
+              limit_and_offset[arg.name] = arg.value
+              true
+            else
+              false
+            end
+          end
+          Api::V1::GraphqlController.limit_and_offset = limit_and_offset
+        end
       end
     end
   end


### PR DESCRIPTION
Add metadata for GraphQL requests. It includes the count, which ignores the limit and offset for the root element. This behaviour is similar to our REST-API and it makes both of them to be more consistent.

Here you can see the output with limit and offset:
```
{
  "meta":{"count":6,"limit":2,"offset":3},
  "data":[
    {
      "id":"4",
      "created_at":"2020-11-25T14:02:36.848Z",
      "source_type_id":"2",
      "name":"Ansible Tower Source","tenant":"0",
      "uid":"23d05717-ad56-4eec-8c34-cc0322e2c411",
      "updated_at":"2020-12-09T12:44:15.640Z",
      "applications":[{"application_type_id":"4","id":"3"}],
      "endpoints":[{"id":"3","scheme":"https","host":"tower.example.com","port":null,"path":"/"}]
    },
    {
      "id":"5",
      "created_at":"2020-11-25T14:02:39.948Z",
      "source_type_id":"3",
      "name":"Azure Source",
      "tenant":"0",
      "uid":"4af9131d-d200-4516-950e-83f9926462a9",
      "updated_at":"2020-11-25T14:02:39.948Z",
      "applications":[{"application_type_id":"4","id":"4"}],
      "endpoints":[{"id":"4","scheme":null,"host":null,"port":null,"path":"/"}]
    }
  ]
}
```
 **before:**
![Screenshot from 2020-12-14 14-49-29](https://user-images.githubusercontent.com/19405716/102090684-0d6b2a00-3e1e-11eb-8c0c-60666356d040.png)

**after:**
![Screenshot from 2020-12-14 14-46-47](https://user-images.githubusercontent.com/19405716/102091025-84a0be00-3e1e-11eb-8ac8-2d8a3129bd61.png)

This PR is based on https://issues.redhat.com/browse/RHCLOUD-9332.