### PR TITLE
[WIP]Graphql provide metadata

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -3,6 +3,10 @@ require "insights/api/common/graphql"
 module Api
   module V1
     class GraphqlController < ApplicationController
+      class << self
+        attr_accessor :limits_and_offsets
+      end
+
       def query
         schema_overlay = {
           "^.+$" => {
@@ -19,7 +23,86 @@ module Api
           params[:query],
           :variables => variables
         )
-        render :json => result
+        meta = calculate_metadata(result) || {}
+        apply_limits_and_offsets(result)
+
+        render :json => result.to_h.merge({'meta' => meta})
+      ensure
+        Api::V1::GraphqlController.limits_and_offsets = {}
+      end
+
+      private
+
+      def calculate_metadata(data)
+        result = {}
+
+        data.to_h["data"]&.each do |o|
+          result[o.first] = o.second.size
+        end
+
+        {"count" => result}
+      end
+
+      def apply_limits_and_offsets(data)
+        result = data.to_h["data"]
+        limits_and_offsets = Api::V1::GraphqlController.limits_and_offsets
+        return unless limits_and_offsets
+
+        result&.each do |o|
+          name = o.first
+          args = limits_and_offsets[name]
+
+          result[name] = apply_offset(result[name], args["offset"]) if args["offset"]
+          result[name] = apply_limit(result[name], args["limit"]) if args["limit"]
+        end
+      end
+
+      def apply_offset(data, offset)
+        offset <= data.size ? data[offset..-1] : []
+      end
+
+      def apply_limit(data, limit)
+        data[0..limit - 1]
+      end
+    end
+  end
+end
+
+module GraphQL
+  module Execution
+    class Execute
+      class << self
+        def begin_query(query, _multiplex)
+          remove_offsets_and_limits(query)
+
+          ExecutionFunctions.resolve_root_selection(query)
+        end
+
+        private
+
+        # Remove and save limit/offset for root elements inside the query
+        def remove_offsets_and_limits(query)
+          query.selected_operation.children.each do |subquery|
+            process_subquery(subquery) unless subquery.arguments.empty?
+          end
+        end
+
+        def process_subquery(query)
+          name = query.name
+          limits_and_offsets = {}
+
+          query.arguments.delete_if do |arg|
+            if arg.name == 'offset' || arg.name == 'limit'
+              limits_and_offsets[arg.name] = arg.value
+              true
+            else
+              false
+            end
+          end
+
+          Api::V1::GraphqlController.limits_and_offsets ||= {}
+          Api::V1::GraphqlController.limits_and_offsets[name] = limits_and_offsets
+        end
       end
     end
   end

--- a/spec/requests/api/graphql_controller_spec.rb
+++ b/spec/requests/api/graphql_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe("v1.0 - GraphQL") do
     before { stub_const("ENV", "BYPASS_TENANCY" => nil) }
 
     it "returns the external tenant identifier" do
-      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity }
+      headers = {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity}
 
       post("/api/v1.0/graphql", :headers => headers, :params => graphql_source_query)
 
@@ -21,12 +21,86 @@ RSpec.describe("v1.0 - GraphQL") do
     end
 
     it "with non-org-admin: returns the external tenant identifier" do
-      headers = { "CONTENT_TYPE" => "application/json", "x-rh-identity" => non_org_admin_identity }
+      headers = {"CONTENT_TYPE" => "application/json", "x-rh-identity" => non_org_admin_identity}
 
       post("/api/v1.0/graphql", :headers => headers, :params => graphql_source_query)
 
       expect(response.status).to eq(200)
       expect(result_source_tenant(response.body)).to match_array([tenant.external_tenant])
+    end
+  end
+
+  context "limits and offsets for root elements" do
+    let!(:source2) { create(:source, :tenant => tenant, :name => "sample_source2", :uid => "1234") }
+    let!(:source3) { create(:source, :tenant => tenant, :name => "sample_source3", :uid => "12345") }
+    let!(:source4) { create(:source, :tenant => tenant, :name => "sample_source4", :uid => "123456") }
+
+    before do
+      headers = {"CONTENT_TYPE" => "application/json", "x-rh-identity" => non_org_admin_identity}
+
+      post("/api/v1.0/graphql", :headers => headers, :params => graphql_source_query)
+    end
+
+    context 'limit' do
+      let(:graphql_source_query) { {"query" => "{ sources(limit:2) { name, id, uid } }"}.to_json }
+
+      it 'works properly' do
+        expected_result = {
+          "data" => {
+            "sources" => [
+              {"name" => source.name, "id" => source.id.to_s, "uid" => source.uid.to_s},
+              {"name" => source2.name, "id" => source2.id.to_s, "uid" => source2.uid.to_s}
+            ]
+          },
+          "meta" => {"count" => {"sources" => 4}}
+        }
+        expect(response.status).to eq(200)
+
+        result = JSON.parse(response.body)
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'offset' do
+      let(:graphql_source_query) { {"query" => "{ sources(offset:2) { name, id, uid } }"}.to_json }
+
+      it 'works properly' do
+        expected_result = {
+          "data" => {
+            "sources" => [
+              {"name" => source3.name, "id" => source3.id.to_s, "uid" => source3.uid.to_s},
+              {"name" => source4.name, "id" => source4.id.to_s, "uid" => source4.uid.to_s}
+            ]
+          },
+          "meta" => {"count" => {"sources" => 4}}
+        }
+        expect(response.status).to eq(200)
+
+        result = JSON.parse(response.body)
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'limit and offset' do
+      context 'single root element' do
+        let(:graphql_source_query) { {"query" => "{ sources(offset:1, limit:2) { name, id, uid } }"}.to_json }
+
+        it 'works properly' do
+          expected_result = {
+            "data" => {
+              "sources" => [
+                {"name" => source2.name, "id" => source2.id.to_s, "uid" => source2.uid.to_s},
+                {"name" => source3.name, "id" => source3.id.to_s, "uid" => source3.uid.to_s}
+              ]
+            },
+            "meta" => {"count" => {"sources" => 4}}
+          }
+          expect(response.status).to eq(200)
+
+          result = JSON.parse(response.body)
+          expect(result).to eq(expected_result)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add metadata for GraphQL requests. It includes the count, which ignores limits and offsets for all root elements. This behaviour is similar to our REST-API and it makes both of them to be more consistent.

Data output:
 * query: 
```
query { 
  applications(offset:1, limit:2) {
    application_type_id,
    id
  },
  endpoints(offset:2, limit:1) {
    id,
    scheme,
    host,
    port,
    path
  } 
}
```
 * before:
```
{
  "data":{
    "applications":[
      {"application_type_id":"4","id":"2"},
      {"application_type_id":"4","id":"3"}
    ],
    "endpoints":[{"id":"3","scheme":"https","host":"tower.example.com","port":null,"path":"/"}]
  }
}
```
 * after: 
```
{
  "data":{
    "applications":[
      {"application_type_id":"4","id":"2"},
      {"application_type_id":"4","id":"3"}
    ],
    "endpoints":[{"id":"3","scheme":"https","host":"tower.example.com","port":null,"path":"/"}]
  },
  "meta":{"count":{"applications":4,"endpoints":5}}
}
```

This PR is based on https://issues.redhat.com/browse/RHCLOUD-9332