### PR TITLE
Add availability_status concern

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,6 +1,7 @@
 class Application < ApplicationRecord
   include TenancyConcern
   include EventConcern
+  include AvailabilityStatusConcern
 
   belongs_to :source
   belongs_to :application_type

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -2,6 +2,7 @@ class Authentication < ApplicationRecord
   include PasswordConcern
   include TenancyConcern
   include EventConcern
+  include AvailabilityStatusConcern
   encrypt_column :password
 
   belongs_to :resource, :polymorphic => true

--- a/app/models/concerns/availability_status_concern.rb
+++ b/app/models/concerns/availability_status_concern.rb
@@ -1,0 +1,31 @@
+module AvailabilityStatusConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_update :update_status
+  end
+
+  private
+
+  IGNORE_LIST = [
+    "availability_status",
+    "availability_status_error",
+    "last_available_at",
+    "last_checked_at",
+    "updated_at",
+    "name"
+  ].freeze
+
+  def update_status
+    updated_attributes = changed - IGNORE_LIST
+
+    if updated_attributes.any?
+      self.availability_status = nil
+      self.last_checked_at = nil
+
+      if respond_to?(:availability_status_error)
+        self.availability_status_error = nil
+      end
+    end
+  end
+end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,6 +1,7 @@
 class Endpoint < ApplicationRecord
   include TenancyConcern
   include EventConcern
+  include AvailabilityStatusConcern
   belongs_to :source
 
   has_many   :authentications, :as => :resource, :dependent => :destroy

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,6 +1,7 @@
 class Source < ApplicationRecord
   include TenancyConcern
   include EventConcern
+  include AvailabilityStatusConcern
   attribute :uid, :string, :default => -> { SecureRandom.uuid }
 
   has_many :applications, :dependent => :destroy

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -1,5 +1,13 @@
+require "models/shared/availability_status.rb"
+
 RSpec.describe("Application") do
   describe "create!" do
+    it_behaves_like "availability_status" do
+      let!(:record)    { create(:application, :source => create(:source), :extra => 'old_data') }
+      let!(:update)    { {:extra => 'new_data'} }
+      let!(:no_update) { {:extra => 'old_data'} }
+    end
+
     subject do
       create(:application, :source => source)
     end

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,9 @@
+require "models/shared/availability_status.rb"
+
+describe Authentication do
+  it_behaves_like "availability_status" do
+    let!(:record)    { create(:authentication, :resource => create(:endpoint)) }
+    let!(:update)    { {:username => 'new_username', :password => 'new_password'} }
+    let!(:no_update) { {:username => record.username} }
+  end
+end

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -1,5 +1,13 @@
+require "models/shared/availability_status.rb"
+
 describe Endpoint do
   include ::Spec::Support::TenantIdentity
+
+  it_behaves_like "availability_status" do
+    let!(:record)    { create(:endpoint, :source => create(:source)) }
+    let!(:update)    { {:path => 'new_path'} }
+    let!(:no_update) { {:path => record.path} }
+  end
 
   describe "#base_url_path" do
     let(:endpoint) { described_class.new(:host => "www.example.com", :port => 1234, :scheme => "https") }

--- a/spec/models/shared/availability_status.rb
+++ b/spec/models/shared/availability_status.rb
@@ -1,0 +1,80 @@
+RSpec.shared_examples "availability_status" do
+  # record, update and no_update variables come from caller spec
+  describe "#before_update" do
+    let(:timestamp)                 { Time.current }
+    let(:new_timestamp)             { Time.current + 1.hour }
+    let(:available_status)          { "available" }
+    let(:unavailable_status)        { "unavailable" }
+    let(:new_name)                  { "new_name" }
+    let(:availability_status_error) { "availability_status_error" }
+
+    let(:ignored_attributes) do
+      new_attributes = {
+        :availability_status => unavailable_status,
+        :last_checked_at     => new_timestamp,
+        :last_available_at   => new_timestamp
+      }
+
+      if record.respond_to?(:updated_at)
+        new_attributes[:updated_at] = new_timestamp
+      end
+
+      if record.respond_to?(:availability_status_error)
+        new_attributes[:availability_status_error] = availability_status_error
+      end
+
+      if record.respond_to?(:name)
+        new_attributes[:name] = new_name
+      end
+
+      new_attributes
+    end
+
+    before do
+      record.availability_status = available_status
+      record.last_checked_at = timestamp
+    end
+
+    context "with changes" do
+      it "sets availability_status to nil" do
+        record.update!(update)
+
+        expect(record.availability_status).to eq(nil)
+        expect(record.last_checked_at).to eq(nil)
+
+        if record.respond_to?(:availability_status_error)
+          expect(record.availability_status_error).to eq(nil)
+        end
+      end
+
+      it "ignores attribute changes from IGNORE_LIST" do
+        record.update!(ignored_attributes)
+
+        expect(record.availability_status).to eq(unavailable_status)
+        expect(record.last_checked_at).to eq(ignored_attributes[:last_checked_at])
+        expect(record.last_available_at).to eq(ignored_attributes[:last_available_at])
+
+        if record.respond_to?(:updated_at)
+          expect(record.updated_at).to eq(new_timestamp)
+        end
+
+        if record.respond_to?(:availability_status_error)
+          expect(record.availability_status_error).to eq(availability_status_error)
+        end
+
+        if record.respond_to?(:name)
+          expect(record.name).to eq(new_name)
+        end
+      end
+    end
+
+    context "without changes" do
+      it "keeps availability_status unchanged" do
+        record.update!(no_update)
+
+        expect(record.availability_status).to eq(available_status)
+        expect(record.last_checked_at).to eq(timestamp)
+      end
+    end
+  end
+end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,0 +1,9 @@
+require "models/shared/availability_status.rb"
+
+describe Source do
+  it_behaves_like "availability_status" do
+    let!(:record)    { create(:source, :version => '1') }
+    let!(:update)    { {:version => '1.1'} }
+    let!(:no_update) { {:version => '1'} }
+  end
+end


### PR DESCRIPTION
Since we cannot be sure about the `availability_status` after attribute update, we are adding the availability_status concern, which removes `availability_status`, `availability_status_error` and `last_checked_at` attributes from `Sources`, `Applications`, `Endpoints` and `Authentications`.

This PR is based on https://issues.redhat.com/browse/RHCLOUD-10278.