### PR TITLE
Pass on headers that come through the Availability Status Listener

### DIFF
--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -51,7 +51,7 @@ class AvailabilityStatusListener
     options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
 
     object.update!(options)
-    raise_event("#{model_class}.update", object.as_json)
+    raise_event("#{model_class}.update", object.as_json, event.headers)
   rescue NameError
     Rails.logger.error("Invalid resource_type #{payload["resource_type"]}")
   rescue ActiveRecord::RecordNotFound
@@ -62,8 +62,8 @@ class AvailabilityStatusListener
     Rails.logger.error(["Something is wrong when processing Kafka message: ", e.message, *e.backtrace].join($RS))
   end
 
-  def raise_event(event, payload)
-    Sources::Api::Events.raise_event(event, payload)
+  def raise_event(event, payload, headers)
+    Sources::Api::Events.raise_event(event, payload, headers)
   rescue => e
     Rails.logger.error(["Failed to send Kafka message with event type(#{event}): ", e.message, *e.backtrace].join($RS))
   end

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe AvailabilityStatusListener do
         let(:status) { "available" }
 
         it "updates availability status and last_available_at" do
-          expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything)
+          expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything, anything)
 
           subject.subscribe_to_availability_status
 
@@ -51,7 +51,7 @@ RSpec.describe AvailabilityStatusListener do
 
       context "when status is unavailable" do
         it "updates availability status" do
-          expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything)
+          expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything, anything)
 
           subject.subscribe_to_availability_status
 


### PR DESCRIPTION
The availability status listener wasn't passing on headers, this fixes that. 

\# DEPENDS ON:
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/73
- [x] common gem release