### PR TITLE
Switch to using common gem's `params_for_update`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem 'cloudwatchlogger',     '~> 0.2.1'
-gem 'insights-api-common',  '~> 4.0'
+gem 'insights-api-common',  '~> 5.0'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::API
   include Insights::API::Common::ApplicationControllerMixins::ExceptionHandling
   include Insights::API::Common::ApplicationControllerMixins::RequestBodyValidation
   include Insights::API::Common::ApplicationControllerMixins::RequestPath
+  include Insights::API::Common::ApplicationControllerMixins::Parameters
   include Pundit
 
   BLACKLIST_PARAMS = [:tenant].freeze
@@ -175,10 +176,6 @@ class ApplicationController < ActionController::API
 
   def query_sort_by
     safe_params_for_list[:sort_by]
-  end
-
-  def params_for_update
-    body_params.permit(*api_doc_definition.all_attributes - api_doc_definition.read_only_attributes)
   end
 
   def pundit_user

--- a/spec/requests/api/rbac_spec.rb
+++ b/spec/requests/api/rbac_spec.rb
@@ -53,7 +53,7 @@ describe("RBAC requests") do
         expect(response).to have_attributes(
           :status      => 403,
           :location    => nil,
-          :parsed_body => {"errors"=>[{"status" => "403", "detail" => "You are not authorized to create this source"}]}
+          :parsed_body => {"errors"=>[{"status" => "403", "detail" => "You are not authorized to perform the create action for this source"}]}
         )
       end
     end


### PR DESCRIPTION
After adding `:extra` to the `Application` model it was reported by @dccurtis that patch-ing extra wasn't working.

Digging into it a bit resulted in having to switch to using the common gem's `params_for_update` method from the Parameters mixin. 

---

This change also exposed some problems in the common gem method as well, so there is a subsequent PR over there that will be linked here.

\# DEPENDS ON:
- [x] https://github.com/RedHatInsights/insights-api-common-rails/pull/213
- [x] https://github.com/RedHatInsights/insights-api-common-rails/pull/215