### PR TITLE
Add meta_data table + models + seeding

### DIFF
--- a/app/models/app_meta_data.rb
+++ b/app/models/app_meta_data.rb
@@ -1,0 +1,24 @@
+class AppMetaData < MetaData
+  belongs_to :application_type
+
+  def self.seed
+    transaction do
+      env = ENV['SOURCES_ENV']
+      raise "No SOURCES_ENV set, cannot continue seeding." unless env
+
+      destroy_all
+
+      metadata = YAML.safe_load(File.read("db/seeds/app_metadata.yml"))
+      metadata[env].each do |app, settings|
+        apptype = ApplicationType.find_by(:name => app)
+
+        settings.each do |key, value|
+          apptype.app_meta_data.create!(
+            :name    => key,
+            :payload => value
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -4,4 +4,6 @@ class ApplicationType < ApplicationRecord
 
   has_many :applications
   has_many :sources, :through => :applications
+  has_many :app_meta_data, :dependent => :destroy, :class_name => "AppMetaData"
+  has_many :super_key_meta_data, :dependent => :destroy, :class_name => "SuperKeyMetaData"
 end

--- a/app/models/meta_data.rb
+++ b/app/models/meta_data.rb
@@ -1,0 +1,2 @@
+class MetaData < ApplicationRecord
+end

--- a/app/models/super_key_meta_data.rb
+++ b/app/models/super_key_meta_data.rb
@@ -1,0 +1,34 @@
+class SuperKeyMetaData < AppMetaData
+  belongs_to :application_type
+
+  default_scope { order(:step) }
+
+  # required for the order of operations
+  validates :step, :presence => true
+  validates :name,
+            :inclusion => {:in      => ["s3", "role", "policy", "bind_role", "cost_report"],
+                           :message => "%{value} is not a supported superkey operation"},
+            :presence  => true
+
+  def self.seed
+    transaction do
+      destroy_all
+
+      YAML.safe_load(File.read("db/seeds/superkey_metadata.yml"))
+          .deep_symbolize_keys
+          .each do |app, settings|
+        apptype = ApplicationType.find_by(:name => app)
+
+        settings[:steps].each do |step|
+          create!(
+            :application_type => apptype,
+            :step             => step[:step],
+            :name             => step[:name],
+            :payload          => step[:payload],
+            :substitutions    => step[:substitutions]
+          )
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20210119201052_create_meta_data.rb
+++ b/db/migrate/20210119201052_create_meta_data.rb
@@ -1,0 +1,13 @@
+class CreateMetaData < ActiveRecord::Migration[5.2]
+  def change
+    create_table :meta_data do |t|
+      t.integer :application_type_id
+      t.integer :step
+      t.string :name
+      t.jsonb :payload
+      t.jsonb :substitutions
+
+      t.timestamps
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,4 @@
 ApplicationType.seed
 SourceType.seed
+SuperKeyMetaData.seed
+AppMetaData.seed

--- a/db/seeds/app_metadata.yml
+++ b/db/seeds/app_metadata.yml
@@ -1,0 +1,19 @@
+######
+# Seed file for application specific metadata.
+# Outer object is the env (in case there are per-env settings)
+# Innter object is in the form of `key`: `jsonb`, but a plain
+# string is valid json. So plain key/value works fine.
+#####
+
+ci:
+  "/insights/platform/cost-management":
+    gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
+qa:
+  "/insights/platform/cost-management":
+    gcp_service_account: test-billing-service-account@cloud-billing-292519.iam.gserviceaccount.com
+stage:
+  "/insights/platform/cost-management":
+    gcp_service_account: ccc
+prod:
+  "/insights/platform/cost-management":
+    gcp_service_account: ddd

--- a/db/seeds/superkey_metadata.yml
+++ b/db/seeds/superkey_metadata.yml
@@ -1,0 +1,117 @@
+---
+"/insights/platform/cost-management":
+  steps:
+  - step: 1
+    name: s3
+    payload:
+      bucket_name: S3
+    substitutions:
+      S3: gen_s3_name
+  - step: 2
+    name: policy
+    payload:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+              "s3:Get*",
+              "s3:List*"
+            ],
+            "Resource": [
+              "arn:aws:s3:::S3BUCKET",
+              "arn:aws:s3:::S3BUCKET/*"
+            ]
+          },
+          {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": [
+              "s3:HeadBucket",
+              "cur:DescribeReportDefinitions"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+    substitutions:
+    - S3BUCKET: s3
+  - step: 3
+    name: role
+    payload:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::ACCOUNT:root"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {}
+          }
+        ]
+      }
+    substitutions:
+    - ACCOUNT: get_account
+  - step: 3
+    name: bind_role
+    payload: {}
+    substitutions: []
+
+"/insights/platform/cloud-meter":
+  steps:
+  - step: 1
+    name: policy
+    payload:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "CloudigradePolicy",
+            "Effect": "Allow",
+            "Action": [
+              "ec2:DescribeImages",
+              "ec2:DescribeInstances",
+              "ec2:ModifySnapshotAttribute",
+              "ec2:DescribeSnapshotAttribute",
+              "ec2:DescribeSnapshots",
+              "ec2:CopyImage",
+              "ec2:CreateTags",
+              "ec2:DescribeRegions",
+              "cloudtrail:CreateTrail",
+              "cloudtrail:UpdateTrail",
+              "cloudtrail:PutEventSelectors",
+              "cloudtrail:DescribeTrails",
+              "cloudtrail:StartLogging",
+              "cloudtrail:DeleteTrail"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+    substitutions: []
+  - step: 2
+    name: role
+    payload:
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::ACCOUNT:root"
+            },
+            "Action": "sts:AssumeRole",
+            "Condition": {}
+          }
+        ]
+      }
+    substitutions:
+      ACCOUNT: get_account
+  - step: 3
+    name: bind_role
+    payload: {}
+    substitutions: []


### PR DESCRIPTION
Heres the initial modeling for AppMetaData ~`AppMetaDatum` (latin anyone? since data is apparently plural)~. 

EDIT: ended up making MetaData a STI class. We now have 2 subclasses: `SuperKeyMetaData` and `AppMetaData`. They will both be seeded. 

- I set up a manual `seed` method on both since the seeding concern won't work for this type of stuff
- turns out you can embed `json` directly into `yaml`, so we can directly support the JSON payloads in the superkey seeding file. 
- there is an association on `ApplicationType` for both `*meta_data`'s for easy access
- the `name` enum is what defines what we do/do not support for SuperKeyMetaData, can expand as necessary (or the more we support)
- the `substitutions` column is what holds the key-value pairs of what should be substituted out of the JSON string payload. 

e2e-deploy PR here for `SOURCES_ENV` required for AppMetaData seeding: https://github.com/RedHatInsights/e2e-deploy/pull/2681