### PR TITLE
Migrate ARN Authentications from storing ARN in password -> username

### DIFF
--- a/db/migrate/20210121161913_move_arn_auth_to_username.rb
+++ b/db/migrate/20210121161913_move_arn_auth_to_username.rb
@@ -1,0 +1,23 @@
+class MoveArnAuthToUsername < ActiveRecord::Migration[5.2]
+  def up
+    Authentication.transaction do
+      Authentication.where(:authtype => %w[arn cloud-meter-arn]).each do |auth|
+        # skip if the resource doesn't exist. e.g. it's a dangling auth
+        next if auth.resource.nil?
+
+        auth.update!(:username => auth.password)
+      end
+    end
+  end
+
+  def down
+    Authentication.transaction do
+      Authentication.where(:authtype => %w[arn cloud-meter-arn]).each do |auth|
+        # skip if the resource doesn't exist. e.g. it's a dangling auth
+        next if auth.resource.nil?
+
+        auth.update!(:username => nil)
+      end
+    end
+  end
+end

--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -35,7 +35,7 @@ amazon:
         - :type: required
         - :type: pattern
           :pattern: "^[A-Za-z0-9]+[A-Za-z0-9_-]*$"
-      - :name: authentication.password
+      - :name: authentication.username
         :stepKey: arn
         :component: text-field
         :label: ARN
@@ -54,7 +54,7 @@ amazon:
         :hideField: true
         :initializeOnMount: true
         :initialValue: cloud-meter-arn
-      - :name: authentication.password
+      - :name: authentication.username
         :component: text-field
         :label: ARN
         :isRequired: true


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-11834

cc @rvsia 

Backend migration for moving the arn/cloud-meter-arn authentications over to using username instead of password.

I left the data in the password for backward compatibility as well. 

---

EDIT: adding wait to merge so we can do this in sync with the UI. 