### PR TITLE
Add app_meta_data endpoints

### DIFF
--- a/app/controllers/api/v3x1.rb
+++ b/app/controllers/api/v3x1.rb
@@ -1,0 +1,18 @@
+module Api
+  module V3x1
+    class RootController < ApplicationController
+      def openapi
+        render :json => ::Insights::API::Common::OpenApi::Docs.instance["3.1"].to_json
+      end
+    end
+
+    class ApplicationsController     < Api::V3x0::ApplicationsController; end
+    class ApplicationTypesController < Api::V3x0::ApplicationTypesController; end
+    class ApplicationAuthenticationsController < Api::V3x0::ApplicationAuthenticationsController; end
+    class AuthenticationsController  < Api::V3x0::AuthenticationsController; end
+    class EndpointsController        < Api::V3x0::EndpointsController; end
+    class GraphqlController          < Api::V3x0::GraphqlController; end
+    class SourcesController          < Api::V3x0::SourcesController; end
+    class SourceTypesController      < Api::V3x0::SourceTypesController; end
+  end
+end

--- a/app/controllers/api/v3x1/app_meta_data_controller.rb
+++ b/app/controllers/api/v3x1/app_meta_data_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V3x1
+    class AppMetaDataController < ApplicationController
+      include ::Api::V1::Mixins::ShowMixin
+
+      # things are starting to get hairy, since v3x0 is overriding the `index` method,
+      # but not providing the other two, so we need to include them both.
+      include ::Api::V1::Mixins::IndexMixin
+      include ::Api::V3x0::Mixins::IndexMixin
+
+      def model
+        AppMetaData
+      end
+    end
+  end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,8 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections do |inflect|
+  # because latin is not welcome here
+  inflect.irregular('MetaData', 'MetaDatum')
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,9 +12,38 @@ Rails.application.routes.draw do
   get "/health", :to => "status#health"
 
   scope :as => :api, :module => "api", :path => prefix do
-    routing_helper.redirect_major_version("v3.0", prefix)
+    routing_helper.redirect_major_version("v3.1", prefix)
     routing_helper.redirect_major_version("v2.0", prefix)
     routing_helper.redirect_major_version("v1.0", prefix)
+
+    namespace :v3x1, :path => "v3.1" do
+      get "/openapi.json", :to => "root#openapi"
+      post "/graphql", :to => "graphql#query"
+
+      resources :application_types,           :only => [:index, :show] do
+        resources :sources, :only => [:index]
+        get "app_meta_data", :to => "app_meta_data#index"
+      end
+      resources :applications,                :only => [:create, :destroy, :index, :show, :update] do
+        resources :authentications, :only => [:index]
+      end
+      resources :application_authentications, :only => [:create, :destroy, :index, :show, :update]
+      resources :authentications,             :only => [:create, :destroy, :index, :show, :update]
+      resources :endpoints,                   :only => [:create, :destroy, :index, :show, :update] do
+        resources :authentications, :only => [:index]
+      end
+      resources :source_types,                :only => [:index, :show] do
+        resources :sources, :only => [:index]
+      end
+      resources :sources,                     :only => [:create, :destroy, :index, :show, :update] do
+        post "check_availability", :to => "sources#check_availability", :action => "check_availability"
+        resources :application_types, :only => [:index]
+        resources :applications,      :only => [:index]
+        resources :authentications,   :only => [:index]
+        resources :endpoints,         :only => [:index]
+      end
+      resources :app_meta_data, :only => [:index, :show,]
+    end
 
     namespace :v3x0, :path => "v3.0" do
       get "/openapi.json", :to => "root#openapi"

--- a/db/migrate/20210126142101_add_type_to_meta_data.rb
+++ b/db/migrate/20210126142101_add_type_to_meta_data.rb
@@ -1,0 +1,7 @@
+# :type was apparently dropped during one of my rebases.
+# Not sure why but we definitely need it.
+class AddTypeToMetaData < ActiveRecord::Migration[5.2]
+  def change
+    add_column :meta_data, :type, :string
+  end
+end

--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -1,0 +1,2226 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "description": "Sources",
+    "version": "3.1.0",
+    "title": "Sources",
+    "contact": {
+      "email": "support@redhat.com"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "security": [
+    {
+      "UserSecurity": []
+    }
+  ],
+  "paths": {
+    "/application_authentications": {
+      "get": {
+        "summary": "List ApplicationAuthentications",
+        "operationId": "listAllApplicationAuthentications",
+        "description": "Returns an array of ApplicationAuthentication objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationAuthentications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationAuthenticationsCollection"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new ApplicationAuthentication",
+        "operationId": "createApplicationAuthentication",
+        "description": "Creates a ApplicationAuthentication object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationAuthentication"
+              }
+            }
+          },
+          "description": "ApplicationAuthentication attributes to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "ApplicationAuthentication creation successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationAuthentication"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/application_authentications/{id}": {
+      "get": {
+        "summary": "Show an existing ApplicationAuthentication",
+        "operationId": "showApplicationAuthentication",
+        "description": "Returns a ApplicationAuthentication object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationAuthentication info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationAuthentication"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an existing ApplicationAuthentication",
+        "operationId": "updateApplicationAuthentication",
+        "description": "Updates a ApplicationAuthentication object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ApplicationAuthentication"
+              }
+            }
+          },
+          "description": "ApplicationAuthentication attributes to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Updated, no content"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an existing ApplicationAuthentication",
+        "operationId": "deleteApplicationAuthentication",
+        "description": "Deletes a ApplicationAuthentication object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "ApplicationAuthentication deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/application_types": {
+      "get": {
+        "summary": "List ApplicationTypes",
+        "operationId": "listApplicationTypes",
+        "description": "Returns an array of ApplicationType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationTypesCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/application_types/{id}": {
+      "get": {
+        "summary": "Show an existing ApplicationType",
+        "operationId": "showApplicationType",
+        "description": "Returns a ApplicationType object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationType info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationType"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/application_types/{id}/sources": {
+      "get": {
+        "summary": "List Sources for ApplicationType",
+        "operationId": "listApplicationTypeSources",
+        "description": "Returns an array of Source objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sources collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourcesCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/application_types/{id}/app_meta_data": {
+      "get": {
+        "summary": "List AppMetaData for ApplicationType",
+        "operationId": "listApplicationTypeAppMetaData",
+        "description": "Returns an array of AppMetaData objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AppMetaData collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppMetaDatumCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications": {
+      "get": {
+        "summary": "List Applications",
+        "operationId": "listApplications",
+        "description": "Returns an array of Application objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationsCollection"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new Application",
+        "operationId": "createApplication",
+        "description": "Creates a Application object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Application"
+              }
+            }
+          },
+          "description": "Application attributes to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Application creation successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Application"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}": {
+      "get": {
+        "summary": "Show an existing Application",
+        "operationId": "showApplication",
+        "description": "Returns a Application object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Application info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Application"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an existing Application",
+        "operationId": "updateApplication",
+        "description": "Updates a Application object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Application"
+              }
+            }
+          },
+          "description": "Application attributes to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Updated, no content"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an existing Application",
+        "operationId": "deleteApplication",
+        "description": "Deletes a Application object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Application deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}/authentications": {
+      "get": {
+        "summary": "List Authentications for Application",
+        "operationId": "listApplicationAuthentications",
+        "description": "Returns an array of Authentication objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authentications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationsCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/authentications": {
+      "get": {
+        "summary": "List Authentications",
+        "operationId": "listAuthentications",
+        "description": "Returns an array of Authentication objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authentications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationsCollection"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new Authentication",
+        "operationId": "createAuthentication",
+        "description": "Creates a Authentication object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Authentication"
+              }
+            }
+          },
+          "description": "Authentication attributes to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Authentication creation successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Authentication"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/authentications/{id}": {
+      "get": {
+        "summary": "Show an existing Authentication",
+        "operationId": "showAuthentication",
+        "description": "Returns a Authentication object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authentication info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Authentication"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an existing Authentication",
+        "operationId": "updateAuthentication",
+        "description": "Updates a Authentication object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Authentication"
+              }
+            }
+          },
+          "description": "Authentication attributes to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Updated, no content"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an existing Authentication",
+        "operationId": "deleteAuthentication",
+        "description": "Deletes a Authentication object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Authentication deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/endpoints": {
+      "get": {
+        "summary": "List Endpoints",
+        "operationId": "listEndpoints",
+        "description": "Returns an array of Endpoint objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Endpoints collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointsCollection"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new Endpoint",
+        "operationId": "createEndpoint",
+        "description": "Creates a Endpoint object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Endpoint"
+              }
+            }
+          },
+          "description": "Endpoint attributes to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Endpoint creation successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Endpoint"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/endpoints/{id}": {
+      "get": {
+        "summary": "Show an existing Endpoint",
+        "operationId": "showEndpoint",
+        "description": "Returns a Endpoint object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Endpoint info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Endpoint"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an existing Endpoint",
+        "operationId": "updateEndpoint",
+        "description": "Updates a Endpoint object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Endpoint"
+              }
+            }
+          },
+          "description": "Endpoint attributes to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Updated, no content"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an existing Endpoint",
+        "operationId": "deleteEndpoint",
+        "description": "Deletes a Endpoint object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Endpoint deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/endpoints/{id}/authentications": {
+      "get": {
+        "summary": "List Authentications for Endpoint",
+        "operationId": "listEndpointAuthentications",
+        "description": "Returns an array of Authentication objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authentications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationsCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/graphql": {
+      "post": {
+        "summary": "Perform a GraphQL Query",
+        "operationId": "postGraphQL",
+        "description": "Performs a GraphQL Query",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GraphQLRequest"
+              }
+            }
+          },
+          "description": "GraphQL Query Request",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "GraphQL Query Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GraphQLResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "summary": "Return this API document in JSON format",
+        "operationId": "getDocumentation",
+        "responses": {
+          "200": {
+            "description": "The API document for this version of the API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/source_types": {
+      "get": {
+        "summary": "List SourceTypes",
+        "operationId": "listSourceTypes",
+        "description": "Returns an array of SourceType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SourceTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourceTypesCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/source_types/{id}": {
+      "get": {
+        "summary": "Show an existing SourceType",
+        "operationId": "showSourceType",
+        "description": "Returns a SourceType object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SourceType info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourceType"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/source_types/{id}/sources": {
+      "get": {
+        "summary": "List Sources for SourceType",
+        "operationId": "listSourceTypeSources",
+        "description": "Returns an array of Source objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sources collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourcesCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources": {
+      "get": {
+        "summary": "List Sources",
+        "operationId": "listSources",
+        "description": "Returns an array of Source objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sources collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SourcesCollection"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a new Source",
+        "operationId": "createSource",
+        "description": "Creates a Source object",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Source"
+              }
+            }
+          },
+          "description": "Source attributes to create",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Source creation successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}": {
+      "get": {
+        "summary": "Show an existing Source",
+        "operationId": "showSource",
+        "description": "Returns a Source object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Source info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update an existing Source",
+        "operationId": "updateSource",
+        "description": "Updates a Source object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Source"
+              }
+            }
+          },
+          "description": "Source attributes to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Updated, no content"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an existing Source",
+        "operationId": "deleteSource",
+        "description": "Deletes a Source object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Source deleted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/application_types": {
+      "get": {
+        "summary": "List ApplicationTypes for Source",
+        "operationId": "listSourceApplicationTypes",
+        "description": "Returns an array of ApplicationType objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ApplicationTypes collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationTypesCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/applications": {
+      "get": {
+        "summary": "List Applications for Source",
+        "operationId": "listSourceApplications",
+        "description": "Returns an array of Application objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Applications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApplicationsCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/authentications": {
+      "get": {
+        "summary": "List Authentications for Source",
+        "operationId": "listSourceAuthentications",
+        "description": "Returns an array of Authentication objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Authentications collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthenticationsCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/check_availability": {
+      "post": {
+        "summary": "Checks Availability of a Source",
+        "operationId": "checkAvailabilitySource",
+        "description": "Checks Availability of a Source",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Availability Check Accepted"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/endpoints": {
+      "get": {
+        "summary": "List Endpoints for Source",
+        "operationId": "listSourceEndpoints",
+        "description": "Returns an array of Endpoint objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Endpoints collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EndpointsCollection"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/app_meta_data": {
+      "get": {
+        "summary": "List AppMetaData",
+        "operationId": "listAllAppMetaData",
+        "description": "Returns an array of AppMetaData objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AppMetaData collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppMetaDatumCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/app_meta_data/{id}": {
+      "get": {
+        "summary": "Show an existing AppMetaData",
+        "operationId": "showAppMetaData",
+        "description": "Returns a AppMetaData object",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "AppMetaData info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppMetaDatum"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://cloud.redhat.com/{basePath}",
+      "description": "Production Server",
+      "variables": {
+        "basePath": {
+          "default": "/api/sources/v3.1"
+        }
+      }
+    },
+    {
+      "url": "http://localhost:{port}/{basePath}",
+      "description": "Development Server",
+      "variables": {
+        "port": {
+          "default": "3000"
+        },
+        "basePath": {
+          "default": "/api/sources/v3.1"
+        }
+      }
+    }
+  ],
+  "components": {
+    "parameters": {
+      "ID": {
+        "name": "id",
+        "in": "path",
+        "description": "ID of the resource",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
+        }
+      },
+      "QueryFilter": {
+        "in": "query",
+        "name": "filter",
+        "description": "Filter for querying collections.",
+        "required": false,
+        "style": "deepObject",
+        "explode": true,
+        "schema": {
+          "type": "object"
+        }
+      },
+      "QueryLimit": {
+        "in": "query",
+        "name": "limit",
+        "description": "The numbers of items to return per page.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000,
+          "default": 100
+        }
+      },
+      "QueryOffset": {
+        "in": "query",
+        "name": "offset",
+        "description": "The number of items to skip before starting to collect the result set.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "QuerySortBy": {
+        "in": "query",
+        "name": "sort_by",
+        "description": "The list of attribute and order to sort the result set by.",
+        "required": false,
+        "style": "deepObject",
+        "explode": true,
+        "schema": {
+          "type": "object"
+        }
+      }
+    },
+    "securitySchemes": {
+      "UserSecurity": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    },
+    "schemas": {
+      "Application": {
+        "type": "object",
+        "properties": {
+          "application_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "extra": {
+            "type": "object"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_available_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "last_checked_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationAuthentication": {
+        "type": "object",
+        "properties": {
+          "application_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "authentication_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationAuthenticationsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationAuthentication"
+            }
+          }
+        }
+      },
+      "ApplicationType": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "dependent_applications": {
+            "type": "object"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "supported_authentication_types": {
+            "type": "object"
+          },
+          "supported_source_types": {
+            "type": "object"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationTypesCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApplicationType"
+            }
+          }
+        }
+      },
+      "AppMetaData": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "application_type_id": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AppMetaDatum": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "application_type_id": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "type": "string"
+          },
+          "payload": {
+            "type": "object"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AppMetaDatumCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AppMetaDatum"
+            }
+          }
+        }
+      },
+      "ApplicationsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            }
+          }
+        }
+      },
+      "Authentication": {
+        "type": "object",
+        "properties": {
+          "authtype": {
+            "example": "openshift_default",
+            "type": "string",
+            "readOnly": true
+          },
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
+            "type": "string"
+          },
+          "extra": {
+            "additionalProperties": false,
+            "properties": {
+              "azure": {
+                "additionalProperties": false,
+                "properties": {
+                  "tenant_id": {
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_available_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "last_checked_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "example": "OpenShift default",
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "resource_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "resource_type": {
+            "example": "Endpoint",
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "status": {
+            "example": "valid",
+            "type": "string"
+          },
+          "status_details": {
+            "type": "string"
+          },
+          "username": {
+            "example": "user@example.com",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AuthenticationsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Authentication"
+            }
+          }
+        }
+      },
+      "CollectionLinks": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string"
+          },
+          "last": {
+            "type": "string"
+          },
+          "next": {
+            "type": "string"
+          },
+          "prev": {
+            "type": "string"
+          }
+        }
+      },
+      "CollectionMetadata": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          }
+        }
+      },
+      "Endpoint": {
+        "type": "object",
+        "properties": {
+          "availability_status": {
+            "type": "string"
+          },
+          "availability_status_error": {
+            "type": "string"
+          },
+          "certificate_authority": {
+            "description": "Optional X.509 Certificate Authority",
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "default": {
+            "type": "boolean"
+          },
+          "host": {
+            "description": "URI host component",
+            "example": "www.example.com",
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "last_available_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "last_checked_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "path": {
+            "description": "URI path component",
+            "example": "/api/v1",
+            "type": "string"
+          },
+          "port": {
+            "description": "URI port component",
+            "example": 80,
+            "type": "integer"
+          },
+          "receptor_node": {
+            "description": "Identifier of a receptor node",
+            "type": "string"
+          },
+          "role": {
+            "example": "default",
+            "type": "string"
+          },
+          "scheme": {
+            "description": "URI scheme component",
+            "example": "https",
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "verify_ssl": {
+            "description": "Should SSL be verified",
+            "example": true,
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EndpointsCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Endpoint"
+            }
+          }
+        }
+      },
+      "ErrorNotFound": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "404"
+                },
+                "detail": {
+                  "type": "string",
+                  "example": "Record not found"
+                }
+              }
+            }
+          }
+        }
+      },
+      "GraphQLRequest": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The GraphQL query",
+            "default": "{}"
+          },
+          "operationName": {
+            "type": "string",
+            "description": "If the Query contains several named operations, the operationName controls which one should be executed",
+            "default": ""
+          },
+          "variables": {
+            "type": "object",
+            "description": "Optional Query variables",
+            "nullable": true
+          }
+        },
+        "required": [
+          "query"
+        ]
+      },
+      "GraphQLResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "description": "Results from the GraphQL query"
+          },
+          "errors": {
+            "type": "array",
+            "description": "Errors resulting from the GraphQL query",
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "ID": {
+        "type": "string",
+        "description": "ID of the resource",
+        "pattern": "^\\d+$",
+        "readOnly": true
+      },
+      "Source": {
+        "type": "object",
+        "properties": {
+          "availability_status": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "imported": {
+            "type": "string"
+          },
+          "last_available_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "last_checked_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "example": "Sample Provider",
+            "title": "Name",
+            "type": "string"
+          },
+          "source_ref": {
+            "type": "string"
+          },
+          "source_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid": {
+            "readOnly": true,
+            "title": "Unique ID of the inventory source installation",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "version": {
+            "example": "6.5.0",
+            "readOnly": true,
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SourceType": {
+        "type": "object",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "name": {
+            "example": "openshift",
+            "type": "string"
+          },
+          "product_name": {
+            "example": "OpenShift",
+            "type": "string"
+          },
+          "schema": {
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "vendor": {
+            "example": "Red Hat",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SourceTypesCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SourceType"
+            }
+          }
+        }
+      },
+      "SourcesCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Source"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -69,4 +69,11 @@ FactoryBot.define do
     description     { "Test tenant" }
     external_tenant { rand(1000).to_s }
   end
+
+  factory :app_meta_data do
+    application_type { association(:application_type) }
+
+    name { "my-custom-metadata" }
+    payload { {"account" => 1234} }
+  end
 end

--- a/spec/requests/api/v3.1/app_meta_data_spec.rb
+++ b/spec/requests/api/v3.1/app_meta_data_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe("v3.1 - AppMetaData") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:messaging_client) { instance_double("ManageIQ::Messaging::Client") }
+  before do
+    allow(messaging_client).to receive(:publish_topic)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
+  end
+
+  let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:attributes)       { {"name" => "a_field", "payload" => {"value" => 1234}} }
+  let(:collection_path)  { "/api/v3.1/app_meta_data" }
+
+  describe("/api/v3.1/app_meta_data") do
+    context "get" do
+      it "success: empty collection" do
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "success: non-empty collection" do
+        create(:app_meta_data, attributes)
+
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3.1/application_authentications_spec.rb
+++ b/spec/requests/api/v3.1/application_authentications_spec.rb
@@ -1,0 +1,120 @@
+RSpec.describe("v3.1 - ApplicationAuthentications") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:messaging_client) { instance_double("ManageIQ::Messaging::Client") }
+  before do
+    allow(messaging_client).to receive(:publish_topic)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
+  end
+
+  let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:endpoint)         { create(:endpoint) }
+  let(:authentication)   { create(:authentication, :resource => endpoint) }
+  let(:application)      { create(:application) }
+  let(:attributes)       { {"application_id" => application.id.to_s, "authentication_id" => authentication.id.to_s} }
+  let(:collection_path)  { "/api/v3.1/application_authentications" }
+  let(:payload) do
+    {
+      "application_id"    => application.id.to_s,
+      "authentication_id" => authentication.id.to_s
+    }
+  end
+
+  describe("/api/v3.1/application_authentication") do
+    context "get" do
+      it "success: empty collection" do
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "success: non-empty collection" do
+        create(:application_authentication, attributes)
+
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+        )
+      end
+    end
+
+    context "post" do
+      it "success: with valid body" do
+        post(collection_path, :params => payload.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/application_authentications/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(payload)
+        )
+      end
+
+      it "failure: with extra attributes" do
+        post(collection_path, :params => payload.merge("aaa" => "bbb").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/ApplicationAuthentication does not define properties: aaa").to_h
+        )
+      end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => payload.merge("application_id" => 123).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 123").to_h
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/application_types/:id") do
+    def instance_path(id)
+      File.join(collection_path, id.to_s)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:application_authentication, attributes)
+
+        get(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => a_hash_including(attributes.merge("id" => instance.id.to_s))
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:application_authentication, attributes)
+
+        get(instance_path(instance.id * 1000), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "delete" do
+      it "success: with a valid paylod" do
+        record = create(:application_authentication, payload)
+
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(record.id), :headers => headers)
+
+        expect(response.status).to eq(204)
+        expect(response.parsed_body).to be_empty
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3.1/application_types_spec.rb
+++ b/spec/requests/api/v3.1/application_types_spec.rb
@@ -1,0 +1,103 @@
+RSpec.describe("v3.1 - ApplicationTypes") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:attributes)      { {"name" => "my application type"} }
+  let(:collection_path) { "/api/v3.1/application_types" }
+
+  describe("/api/v3.1/application_types") do
+    context "get" do
+      it "success: empty collection" do
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "success: non-empty collection" do
+        create(:application_type, attributes)
+
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/application_types/:id") do
+    def instance_path(id)
+      File.join(collection_path, id.to_s)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:application_type, attributes)
+
+        get(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => a_hash_including(attributes.merge("id" => instance.id.to_s))
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:application_type, attributes)
+
+        get(instance_path(instance.id * 1000), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+  end
+
+  describe("subcollections") do
+    existing_subcollections = [
+      "sources", "app_meta_data",
+    ]
+
+    existing_subcollections.each do |subcollection|
+      describe("/api/v3.1/application_types/:id/#{subcollection}") do
+        let(:subcollection) { subcollection }
+
+        def subcollection_path(id)
+          File.join(collection_path, id.to_s, subcollection)
+        end
+
+        context "get" do
+          it "success: with a valid id" do
+            instance = create(:application_type, attributes)
+
+            get(subcollection_path(instance.id), :headers => headers)
+
+            expect(response).to have_attributes(
+              :status      => 200,
+              :parsed_body => paginated_response(0, [])
+            )
+          end
+
+          it "failure: with an invalid id" do
+            instance   = create(:application_type, attributes)
+            missing_id = (instance.id * 1000)
+            expect(ApplicationType.exists?(missing_id)).to eq(false)
+
+            get(subcollection_path(missing_id), :headers => headers)
+
+            expect(response).to have_attributes(
+              :status      => 404,
+              :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3.1/applications_spec.rb
+++ b/spec/requests/api/v3.1/applications_spec.rb
@@ -1,0 +1,190 @@
+RSpec.describe("v3.1 - Applications") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:client) { instance_double("ManageIQ::Messaging::Client") }
+  before do
+    allow(client).to receive(:publish_topic)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+  end
+
+  let(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:collection_path)  { "/api/v3.1/applications" }
+  let(:source)           { create(:source, :tenant => tenant) }
+  let(:application_type) { create(:application_type) }
+  let(:payload) do
+    {
+      "source_id"           => source.id.to_s,
+      "application_type_id" => application_type.id.to_s
+    }
+  end
+
+  describe("/api/v3.1/applications") do
+    context "get" do
+      it "success: empty collection" do
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "success: non-empty collection" do
+        create(:application, payload.merge(:tenant => tenant))
+
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(1, [a_hash_including(payload)])
+        )
+      end
+    end
+
+    context "post" do
+      it "success: with valid body" do
+        post(collection_path, :params => payload.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/applications/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(payload)
+        )
+      end
+
+      it "failure: with extra attributes" do
+        post(collection_path, :params => payload.merge("aaa" => "bbb").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
+        )
+      end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => payload.merge("availability_status" => 123).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Application/properties/availability_status expected string, but received Integer: 123").to_h
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/applications/:id") do
+    def instance_path(id)
+      File.join(collection_path, id.to_s)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:application, payload.merge(:tenant => tenant))
+
+        get(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => a_hash_including("id" => instance.id.to_s, "tenant" => tenant.external_tenant)
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:application, payload.merge(:tenant => tenant))
+
+        get(instance_path(instance.id * 1000), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "patch" do
+      let(:instance) { create(:application, payload.merge(:tenant => tenant)) }
+      it "success: with a valid id" do
+        new_attributes = {"availability_status" => "available"}
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+
+        expect(instance.reload).to have_attributes(new_attributes)
+      end
+
+      it "failure: with extra attributes" do
+        extra_attributes = {"aaa" => "bbb"}
+
+        patch(instance_path(instance.id), :params => extra_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Application does not define properties: aaa").to_h
+        )
+      end
+
+      it "failure: with an invalid id" do
+        new_attributes = {"availability_status" => "available"}
+
+        patch(instance_path(instance.id * 1000), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "delete" do
+      it "success: with a valid id" do
+        instance = create(:application, payload.merge(:tenant => tenant))
+
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/applications/:id/authentications") do
+    def subcollection_path(id, subcollection)
+      File.join(collection_path, id.to_s, subcollection)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:application, payload.merge(:tenant => tenant))
+
+        get(subcollection_path(instance.id, "authentications"), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:application, payload.merge(:tenant => tenant))
+        missing_id = (instance.id * 1000)
+        expect(Application.exists?(missing_id)).to eq(false)
+
+        get(subcollection_path(missing_id, "authentications"), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3.1/authentications_spec.rb
+++ b/spec/requests/api/v3.1/authentications_spec.rb
@@ -1,0 +1,182 @@
+require "manageiq-messaging"
+
+RSpec.describe("v3.1 - Authentications") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:client) { instance_double("ManageIQ::Messaging::Client") }
+  before do
+    allow(client).to receive(:publish_topic)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+  end
+
+  let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:collection_path) { "/api/v3.1/authentications" }
+  let(:application) { create(:application, :tenant => tenant) }
+
+  let(:payload) do
+    {
+      "username"      => "test_name",
+      "password"      => "Test Password",
+      "resource_type" => "Application",
+      "resource_id"   => application.id.to_s
+    }
+  end
+
+  describe("/api/v3.1/authentications") do
+    context "get" do
+      it "success: empty collection" do
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "success: non-empty collection" do
+        create(:authentication, payload.merge(:tenant => tenant))
+
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(1, [a_hash_including(payload.except("password"))])
+        )
+      end
+    end
+
+    context "post" do
+      it "success: with valid body" do
+        post(collection_path, :params => payload.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/authentications/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(payload.except("password"))
+        )
+      end
+
+      it "success: with valid body containing extra" do
+        payload_with_extra = payload.merge(:extra => {:azure => {:tenant_id => "tenant_id_value"}})
+        post(collection_path, :params => payload_with_extra.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/authentications/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(payload.except("password"))
+        )
+        expect(response.parsed_body["extra"]).to match({"azure" => {"tenant_id" => "tenant_id_value"}})
+      end
+
+      it "failure: with valid body containing invalid extra" do
+        payload_with_extra = payload.merge({:extra => {:amazon => {:tenant_id => "tenant_id_value"}}})
+        post(collection_path, :params => payload_with_extra.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication/properties/extra does not define properties: amazon").to_h
+        )
+      end
+
+      it "failure: with extra attributes" do
+        post(collection_path, :params => payload.merge("aaa" => "bbb").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Authentication does not define properties: aaa").to_h
+        )
+      end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => payload.merge("password" => 123).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Authentication/properties/password expected string, but received Integer: 123").to_h
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/authentications/:id") do
+    def instance_path(id)
+      File.join(collection_path, id.to_s)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:authentication, payload.merge(:tenant => tenant))
+
+        get(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => payload.except("password").merge("id" => instance.id.to_s, "tenant" => tenant.external_tenant, "source_id" => application.source_id.to_s)
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:authentication, payload.merge(:tenant => tenant))
+
+        get(instance_path(instance.id * 1000), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "patch" do
+      let(:instance) { create(:authentication, payload.merge(:tenant => tenant)) }
+      it "success: with a valid id" do
+        new_attributes = {"name" => "new name"}
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+
+        expect(instance.reload).to have_attributes(new_attributes)
+      end
+
+      it "success: with extra attributes" do
+        extra_attributes = {"extra" => {"azure" => {"tenant_id" => "tenant_id_value"}}}
+
+        patch(instance_path(instance.id), :params => extra_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(:status => 204, :parsed_body => "")
+        expect(instance.reload).to have_attributes(extra_attributes)
+      end
+
+      it "failure: with an invalid id" do
+        new_attributes = {"name" => "new name"}
+
+        patch(instance_path(instance.id * 1000), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "delete" do
+      let(:instance) { create(:authentication, payload.merge(:tenant => tenant)) }
+
+      it "success: with a valid id" do
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3.1/endpoints_spec.rb
+++ b/spec/requests/api/v3.1/endpoints_spec.rb
@@ -1,0 +1,184 @@
+require "manageiq-messaging"
+
+RSpec.describe("v3.1 - Endpoints") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:client) { instance_double("ManageIQ::Messaging::Client") }
+  before do
+    allow(client).to receive(:publish_topic)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+  end
+
+  let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:collection_path) { "/api/v3.1/endpoints" }
+  let(:source)          { create(:source, :tenant => tenant) }
+
+  let(:payload) do
+    {
+      "host"                  => "example.com",
+      "port"                  => 443,
+      "role"                  => "default",
+      "path"                  => "api",
+      "source_id"             => source.id.to_s,
+      "scheme"                => "https",
+      "verify_ssl"            => true,
+      "certificate_authority" => "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----",
+    }
+  end
+
+  describe("/api/v3.1/endpoints") do
+    context "get" do
+      it "success: empty collection" do
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "success: non-empty collection" do
+        create(:endpoint, payload.merge(:tenant => tenant))
+
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(1, [a_hash_including(payload)])
+        )
+      end
+    end
+
+    context "post" do
+      it "success: with valid body" do
+        post(collection_path, :params => payload.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/endpoints/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(payload)
+        )
+      end
+
+      it "failure: with extra attributes" do
+        post(collection_path, :params => payload.merge("aaa" => "bbb").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+        )
+      end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => payload.merge("default" => 123).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/Endpoint/properties/default expected boolean, but received Integer: 123").to_h
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/endpoints/:id") do
+    def instance_path(id)
+      File.join(collection_path, id.to_s)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:endpoint, payload.merge(:tenant => tenant))
+
+        get(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => a_hash_including("id" => instance.id.to_s, "tenant" => tenant.external_tenant)
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:endpoint, payload.merge(:tenant => tenant))
+
+        get(instance_path(instance.id * 1000), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "patch" do
+      let(:instance) { create(:endpoint, payload.merge(:tenant => tenant)) }
+      it "success: with a valid id" do
+        new_attributes = {"host" => "example.org"}
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+
+        expect(instance.reload).to have_attributes(new_attributes)
+      end
+
+      it "failure: with extra attributes" do
+        extra_attributes = {"aaa" => "bbb"}
+
+        patch(instance_path(instance.id), :params => extra_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Endpoint does not define properties: aaa").to_h
+        )
+      end
+
+      it "failure: with an invalid id" do
+        new_attributes = {"host" => "example.org"}
+
+        patch(instance_path(instance.id * 1000), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "delete" do
+      let(:instance) { create(:endpoint, payload.merge(:tenant => tenant)) }
+
+      it "success: with a valid id" do
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+
+      it "success: with associated authentications" do
+        authentication_payload = {
+          "username"      => "test_name",
+          "password"      => "Test Password",
+          "resource_type" => "Tenant",
+          "resource_id"   => tenant.id.to_s
+        }
+        create(:authentication, authentication_payload.merge(:tenant => tenant, :resource => instance))
+
+        expect(Sources::Api::Events).to receive(:raise_event).twice
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3.1/filter_spec.rb
+++ b/spec/requests/api/v3.1/filter_spec.rb
@@ -1,0 +1,90 @@
+RSpec.describe("Sources Filtering") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:headers)           { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:api_version)       { "v3.1" }
+  let(:source_collection) { "/api/#{api_version}/sources" }
+
+  def create_source(source_name, opt_params = {})
+    create(:source, {:name => source_name}.merge(opt_params))
+  end
+
+  def expect_success(query, *results)
+    get("#{source_collection}?#{query}", :headers => headers)
+
+    expect(response).to(
+      have_attributes(
+        :parsed_body => paginated_response(results.length, results.collect { |i| a_hash_including("id" => i.id.to_s) }),
+        :status      => 200
+      )
+    )
+  end
+
+  def expect_failure(query, *errors)
+    get("#{source_collection}?#{query}", :headers => headers)
+
+    expect(response).to(
+      have_attributes(
+        :parsed_body => {"errors" => errors.collect { |e| {"detail" => e, "status" => "400"} }},
+        :status      => 400
+      )
+    )
+  end
+
+  context "filtering" do
+    let!(:source_1) { create_source("aaa", :version => "1") }
+    let!(:source_2) { create_source("bbb", :version => "1") }
+    let!(:source_3) { create_source("abc") }
+    let!(:source_4) { create_source("ddd", :version => "2") }
+
+    it("name:eq single without 'eq' key")          { expect_success("filter[name]=#{source_1.name}", source_1) }
+    it("name:eq array of values without 'eq' key") { expect_success("filter[name][]=#{source_1.name}&filter[name][]=#{source_2.name}", source_1, source_2) }
+    it("name:eq single with 'eq' key")             { expect_success("filter[name][eq]=#{source_1.name}", source_1) }
+    it("name:eq array of values with 'eq' key")    { expect_success("filter[name][eq][]=#{source_1.name}&filter[name][eq][]=#{source_2.name}", source_1, source_2) }
+
+    it("name:contains single")                     { expect_success("filter[name][contains]=a", source_1, source_3) }
+    it("name:contains array")                      { expect_success("filter[name][contains][]=a&filter[name][contains][]=b", source_3) }
+
+    it("name:ends_with")                           { expect_success("filter[name][ends_with]=a", source_1) }
+    it("name:starts_with")                         { expect_success("filter[name][starts_with]=b", source_2) }
+
+    it("version:nil")                              { expect_success("filter[version][nil]", source_3) }
+    it("version:not_nil")                          { expect_success("filter[version][not_nil]", source_1, source_2, source_4) }
+  end
+
+  context "sorted results via sort_by" do
+    before do
+      create(:source, :name => "sort_by_source_a")
+      create(:source, :name => "sort_by_source_b")
+    end
+
+    it "available for sources with default order" do
+      get("/api/v3.1/sources?filter[name][starts_with]=sort_by_source&sort_by[name]", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |source| source["name"] }).to eq(%w[sort_by_source_a sort_by_source_b])
+    end
+
+    it "available for sources with desc order" do
+      get("/api/v3.1/sources?filter[name][starts_with]=sort_by_source&sort_by[name]=desc", :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"].collect { |source| source["name"] }).to eq(%w[sort_by_source_b sort_by_source_a])
+    end
+  end
+
+  context "error cases" do
+    let!(:source_1) { create_source("aaa", :version => "1") }
+    let!(:source_2) { create_source("bbb") }
+
+    it("empty filter")      { expect_failure("filter", "ActionController::UnpermittedParameters: found unpermitted parameter: :filter") }
+    it("unknown attribute") { expect_failure("filter[xxx]", "found unpermitted parameter: xxx") }
+
+    it "invalid attribute" do
+      get("#{source_collection}?filter[bogus_attribute]=a", :headers => headers)
+
+      expect(response.status).to(eq(400))
+      expect(response.parsed_body["errors"]).to(eq([{"detail" => "found unpermitted parameter: bogus_attribute", "status" => "400"}]))
+    end
+  end
+end

--- a/spec/requests/api/v3.1/graphql_controller_spec.rb
+++ b/spec/requests/api/v3.1/graphql_controller_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe("v3.1 - GraphQL") do
+  include ::Spec::Support::TenantIdentity
+
+  let!(:graphql_endpoint) { "/api/v3.1/graphql" }
+  let!(:headers)          { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let!(:source_typeR) { create(:source_type, :name => "rhev_sample", :product_name => "RedHat Virtualization", :vendor => "redhat") }
+  let!(:source_typeV) { create(:source_type, :name => "vmware_sample", :product_name => "VmWare vCenter", :vendor => "vmware") }
+  let!(:source_typeO) { create(:source_type, :name => "openstack_sample", :product_name => "OpenStack", :vendor => "redhat") }
+
+  context "support result sorting using the v2 interface" do
+    before { stub_const("ENV", "BYPASS_TENANCY" => nil) }
+
+    it "sort_by with a single attribute" do
+      post(graphql_endpoint, :headers => headers, :params => {"query" => '
+        {
+          source_types(filter: { name: { ends_with: "sample" } }, sort_by: { vendor: "asc" }) {
+            vendor
+          }
+        }'}.to_json)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]["source_types"].collect { |st| st["vendor"] })
+        .to eq(%w[redhat redhat vmware])
+    end
+  end
+end

--- a/spec/requests/api/v3.1/source_types_spec.rb
+++ b/spec/requests/api/v3.1/source_types_spec.rb
@@ -1,0 +1,106 @@
+require "manageiq-messaging"
+
+RSpec.describe("v3.1 - SourceTypes") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:attributes)      { {"name" => "test_name", "product_name" => "Test Product", "vendor" => "TestVendor"} }
+  let(:collection_path) { "/api/v3.1/source_types" }
+
+  describe("/api/v3.1/source_types") do
+    context "get" do
+      it "success: empty collection" do
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "success: non-empty collection" do
+        create(:source_type, attributes)
+
+        get(collection_path, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+        )
+      end
+    end
+
+    context "post" do
+      it "failure: not supported" do
+        post(collection_path, :params => attributes.merge("name" => 123).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status   => 404,
+          :location => nil
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/source_types/:id") do
+    def instance_path(id)
+      File.join(collection_path, id.to_s)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:source_type, attributes)
+
+        get(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => a_hash_including(attributes.merge("id" => instance.id.to_s))
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:source_type, attributes)
+
+        get(instance_path(instance.id * 1000), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+  end
+
+  describe("/api/v3.1/source_types/:id/sources") do
+    def subcollection_path(id, subcollection)
+      File.join(collection_path, id.to_s, subcollection)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:source_type, attributes)
+
+        get(subcollection_path(instance.id, "sources"), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => paginated_response(0, [])
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:source_type, attributes)
+        missing_id = (instance.id * 1000)
+        expect(Source.exists?(missing_id)).to eq(false)
+
+        get(subcollection_path(missing_id, "sources"), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3.1/sources_spec.rb
+++ b/spec/requests/api/v3.1/sources_spec.rb
@@ -1,0 +1,600 @@
+require "webmock/rspec"
+
+RSpec.describe("v3.1 - Sources") do
+  include ::Spec::Support::TenantIdentity
+
+  let(:headers)         { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
+  let(:collection_path) { "/api/v3.1/sources" }
+  let(:source_type)     { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
+  let(:client)          { instance_double("ManageIQ::Messaging::Client") }
+  before do
+    allow(client).to receive(:publish_topic)
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+  end
+
+  describe("/api/v3.1/sources") do
+    context "get" do
+      context "user credentials" do
+        it "success: empty collection" do
+          get(collection_path, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status      => 200,
+            :parsed_body => paginated_response(0, [])
+          )
+        end
+
+        it "success: non-empty collection" do
+          create(:source, attributes.merge("tenant" => tenant))
+
+          get(collection_path, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status      => 200,
+            :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+          )
+        end
+      end
+
+      context "system credentials" do
+        let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => system_identity} }
+
+        it "success: empty collection" do
+          get(collection_path, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status      => 200,
+            :parsed_body => paginated_response(0, [])
+          )
+        end
+
+        it "success: non-empty collection" do
+          create(:source, attributes.merge("tenant" => tenant))
+
+          get(collection_path, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status      => 200,
+            :parsed_body => paginated_response(1, [a_hash_including(attributes)])
+          )
+        end
+      end
+    end
+
+    context "post" do
+      it "success: with valid body" do
+        post(collection_path, :params => attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/sources/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(attributes)
+        )
+      end
+
+      it "failure: with a missing name attribute" do
+        post(collection_path, :params => attributes.except("name").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
+        )
+      end
+
+      it "failure: with extra attributes" do
+        post(collection_path, :params => attributes.merge("aaa" => "bbb").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaa").to_h
+        )
+      end
+
+      it "failure: with a blank name attribute" do
+        post(collection_path, :params => attributes.merge("name" => "").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Name can't be blank").to_h
+        )
+      end
+
+      it "failure: with a null name attribute" do
+        post(collection_path, :params => attributes.merge("name" => nil).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values").to_h
+        )
+      end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => attributes.merge("source_type_id" => "xxx").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::InvalidPattern: #/components/schemas/ID pattern ^\\d+$ does not match value: xxx").to_h
+        )
+      end
+
+      it "failure: with a duplicate name in the same tenant" do
+        2.times do
+          post(collection_path, :params => attributes.to_json, :headers => headers)
+        end
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add(
+            "400", "Invalid parameter - Validation failed: Name has already been taken"
+          ).to_h
+        )
+      end
+
+      it "success: with a duplicate name in a different tenant" do
+        post(collection_path, :params => attributes.to_json, :headers => headers)
+
+        second_tenant = rand(1000).to_s
+        second_identity = {"x-rh-identity" => Base64.encode64({"identity" => {"account_number" => second_tenant, "user" => {"is_org_admin" => true}}}.to_json)}
+        post(collection_path, :params => attributes.to_json, :headers => headers.merge(second_identity))
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/sources/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(attributes)
+        )
+      end
+
+      it "failure: with a not unique UID" do
+        post(collection_path, :params => attributes.merge("name" => "aaa", "uid" => "123").to_json, :headers => headers)
+        post(collection_path, :params => attributes.merge("name" => "abc", "uid" => "123").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Record not unique").to_h
+        )
+      end
+
+      context "with system credentials" do
+        let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => system_identity} }
+
+        it "success: with valid body" do
+          post(collection_path, :params => attributes.to_json, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status      => 201,
+            :location    => "http://www.example.com/api/v3.1/sources/#{response.parsed_body["id"]}",
+            :parsed_body => a_hash_including(attributes)
+          )
+        end
+      end
+    end
+  end
+
+  describe("/api/v3.1/sources/:id") do
+    def instance_path(id)
+      File.join(collection_path, id.to_s)
+    end
+
+    context "get" do
+      it "success: with a valid id" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+
+        get(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 200,
+          :parsed_body => a_hash_including(attributes.merge("id" => instance.id.to_s))
+        )
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+
+        get(instance_path(instance.id * 1000), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+    end
+
+    context "patch" do
+      it "success: with a valid id" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+        new_attributes = {"name" => "new name"}
+
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+
+        expect(instance.reload).to have_attributes(new_attributes)
+      end
+
+      it "failure: with a null value" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+        new_attributes = {"name" => nil}
+
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :parsed_body => {"errors"=>[{"detail" => "OpenAPIParser::NotNullError: #/components/schemas/Source/properties/name does not allow null values", "status" => "400"}]}
+        )
+
+        expect(instance.reload).to have_attributes(:name => "my source")
+      end
+
+      it "failure: with an invalid id" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+        new_attributes = {"name" => "new name"}
+
+        patch(instance_path(instance.id * 1000), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+
+      it "failure: with extra parameters" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+        new_attributes = {"aaaaa" => "bbbbb"}
+
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :parsed_body => {"errors" => [{"detail" => "OpenAPIParser::NotExistPropertyDefinition: #/components/schemas/Source does not define properties: aaaaa", "status" => "400"}]}
+        )
+      end
+
+      it "failure: with read-only parameters" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+        new_attributes = {"uid" => "xxxxx"}
+
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :uid", "status" => "400"}]}
+        )
+      end
+
+      it "failure: with an invalid attribute value" do
+        post(collection_path, :params => attributes.merge("source_type_id" => 4).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "OpenAPIParser::ValidateError: #/components/schemas/ID expected string, but received Integer: 4").to_h
+        )
+      end
+
+      it "failure: with an invalid availability_status value" do
+        post(collection_path, :params => attributes.merge("availability_status" => "bogus").to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :location    => nil,
+          :parsed_body => Insights::API::Common::ErrorDocument.new.add("400", "Invalid parameter - Validation failed: Availability status is not included in the list").to_h
+        )
+      end
+
+      it "success: with an available availability_status" do
+        included_attributes = {"name" => "availability_source", "availability_status" => "available"}
+
+        post(collection_path, :params => attributes.merge(included_attributes).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/sources/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(included_attributes)
+        )
+      end
+
+      it "success: with a partially_available availability_status" do
+        included_attributes = {"name" => "availability_source", "availability_status" => "partially_available"}
+
+        post(collection_path, :params => attributes.merge(included_attributes).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/sources/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(included_attributes)
+        )
+      end
+
+      it "success: with an unavailable availability_status" do
+        included_attributes = {"name" => "availability_source", "availability_status" => "unavailable"}
+
+        post(collection_path, :params => attributes.merge(included_attributes).to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 201,
+          :location    => "http://www.example.com/api/v3.1/sources/#{response.parsed_body["id"]}",
+          :parsed_body => a_hash_including(included_attributes)
+        )
+      end
+
+      it "rejects read_only attributes" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+        new_attributes = {"name" => "new name", "created_at" => Time.now.utc}
+
+        patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 400,
+          :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :created_at", "status" => "400"}]}
+        )
+      end
+    end
+
+    context "delete" do
+      it "success: with a valid id" do
+        instance = create(:source, attributes.merge("tenant" => tenant))
+
+        expect(Sources::Api::Events).to receive(:raise_event).once
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+      end
+
+      it "success: with associated applications" do
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
+        instance    = create(:source, attributes.merge("tenant" => tenant))
+
+        app_type1 = create(:application_type,
+                           :name                   => "/platform/application-type1",
+                           :display_name           => "Application Type One",
+                           :supported_source_types => ["openshift"])
+
+        app_type2 = create(:application_type,
+                           :name                   => "ApplicationType2",
+                           :display_name           => "Application Type Two",
+                           :supported_source_types => ["openshift"])
+
+        app_type1_url = "http://app1.example.com:8001/availability_check"
+        app_type2_url = "http://app2.example.com:8002/availability_check"
+
+        create(:application, :application_type => app_type1, :source => instance, :tenant => tenant)
+        create(:application, :application_type => app_type2, :source => instance, :tenant => tenant)
+
+        tenant_payload = {
+          "host"                  => "example.com",
+          "port"                  => 443,
+          "role"                  => "default",
+          "path"                  => "api",
+          "source_id"             => instance.id.to_s,
+          "scheme"                => "https",
+          "verify_ssl"            => true,
+          "certificate_authority" => "-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----",
+        }
+
+        create(:endpoint, tenant_payload.merge(:tenant => tenant, :source => instance))
+
+        expect(Sources::Api::Events).to receive(:raise_event).exactly(4).times
+        delete(instance_path(instance.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 204,
+          :parsed_body => ""
+        )
+        expect(Application.count).to eq(0)
+      end
+    end
+  end
+
+  describe("/api/v3.1/sources/:id/check_availability") do
+    let(:messaging_client)  { double("Sources::Api::Messaging") }
+    let(:openshift_topic)   { "platform.topological-inventory.operations-openshift" }
+    let(:amazon_topic)      { "platform.topological-inventory.operations-amazon" }
+
+    def check_availability_path(source_id)
+      File.join(collection_path, source_id.to_s, "check_availability")
+    end
+
+    before do
+      allow(messaging_client).to receive(:publish_topic)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
+    end
+
+    context "post" do
+      it "failure: with an invalid id" do
+        post(check_availability_path(99_999), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 404,
+          :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+        )
+      end
+
+      it "success: with valid openshift source" do
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
+        source      = create(:source, attributes.merge("tenant" => tenant))
+
+        expect(messaging_client).to receive(:publish_topic)
+          .with(hash_including(:service => openshift_topic,
+                               :event   => "Source.availability_check",
+                               :payload => a_hash_including(
+                                 :params => a_hash_including(
+                                   :source_id       => source.id.to_s,
+                                   :external_tenant => tenant.external_tenant
+                                 )
+                               )))
+
+        post(check_availability_path(source.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 202,
+          :parsed_body => {}
+        )
+      end
+
+      it "success: with valid amazon source" do
+        source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
+        attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
+        source      = create(:source, attributes.merge("tenant" => tenant))
+
+        expect(messaging_client).to receive(:publish_topic)
+          .with(hash_including(:service => amazon_topic,
+                               :event   => "Source.availability_check",
+                               :payload => a_hash_including(
+                                 :params => a_hash_including(
+                                   :source_id       => source.id.to_s,
+                                   :external_tenant => tenant.external_tenant
+                                 )
+                               )))
+
+        post(check_availability_path(source.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 202,
+          :parsed_body => {}
+        )
+      end
+
+      it "success: with a source-type that topology doesn't support" do
+        source_type = create(:source_type, :name => "vsphere", :vendor => "VMware", :product_name => "VMware vSphere")
+        attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
+        source      = create(:source, attributes.merge("tenant" => tenant))
+
+        post(check_availability_path(source.id), :headers => headers)
+
+        expect(response).to have_attributes(
+          :status      => 202,
+          :parsed_body => {}
+        )
+      end
+
+      it "success: with valid openshift source querying associated applications" do
+        source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
+        attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
+        source      = create(:source, attributes.merge("tenant" => tenant))
+
+        app_type1 = create(:application_type,
+                           :name                   => "/platform/application-type1",
+                           :display_name           => "Application Type One",
+                           :supported_source_types => ["openshift"])
+
+        app_type2 = create(:application_type,
+                           :name                   => "ApplicationType2",
+                           :display_name           => "Application Type Two",
+                           :supported_source_types => ["openshift"])
+
+        app_type1_url = "http://app1.example.com:8001/availability_check"
+        app_type2_url = "http://app2.example.com:8002/availability_check"
+
+        app1 = create(:application, :application_type => app_type1, :source => source, :tenant => tenant)
+        app2 = create(:application, :application_type => app_type2, :source => source, :tenant => tenant)
+
+        source.applications = [app1, app2]
+
+        expect(messaging_client).to receive(:publish_topic)
+          .with(hash_including(:service => openshift_topic,
+                               :event   => "Source.availability_check",
+                               :payload => a_hash_including(
+                                 :params => a_hash_including(
+                                   :source_id       => source.id.to_s,
+                                   :external_tenant => tenant.external_tenant
+                                 )
+                               )))
+
+        request_body = {:source_id => source.id.to_s}.to_json
+
+        stub_request(:post, app_type1_url)
+          .with do |request|
+            request.headers = headers
+            request.body    = request_body
+          end
+          .to_return(:status => 200, :body => "")
+
+        stub_request(:post, app_type2_url)
+          .with do |request|
+            request.headers = headers
+            request.body    = request_body
+          end
+          .to_return(:status => 200, :body => "")
+
+        ENV["APPLICATION_TYPE1_AVAILABILITY_CHECK_URL"] = app_type1_url
+        ENV["APPLICATIONTYPE2_AVAILABILITY_CHECK_URL"]  = app_type2_url
+
+        post(check_availability_path(source.id), :headers => headers)
+
+        assert_requested(:post,
+                         app_type1_url,
+                         :headers => headers,
+                         :body    => request_body,
+                         :times   => 1)
+        assert_requested(:post,
+                         app_type2_url,
+                         :headers => headers,
+                         :body    => request_body,
+                         :times   => 1)
+
+        expect(response).to have_attributes(
+          :status      => 202,
+          :parsed_body => {}
+        )
+      end
+    end
+  end
+
+  describe("subcollections") do
+    existing_subcollections = [
+      "endpoints",
+    ]
+
+    existing_subcollections.each do |subcollection|
+      describe("/api/v3.1/sources/:id/#{subcollection}") do
+        let(:subcollection) { subcollection }
+
+        def subcollection_path(id)
+          File.join(collection_path, id.to_s, subcollection)
+        end
+
+        context "get" do
+          it "success: with a valid id" do
+            instance = create(:source, attributes.merge("tenant" => tenant))
+
+            get(subcollection_path(instance.id), :headers => headers)
+
+            expect(response).to have_attributes(
+              :status      => 200,
+              :parsed_body => paginated_response(0, [])
+            )
+          end
+
+          it "failure: with an invalid id" do
+            instance = create(:source, attributes.merge("tenant" => tenant))
+            missing_id = (instance.id * 1000)
+            expect(Source.exists?(missing_id)).to eq(false)
+
+            get(subcollection_path(missing_id), :headers => headers)
+
+            expect(response).to have_attributes(
+              :status      => 404,
+              :parsed_body => {"errors"=>[{"detail" => "Record not found", "status" => "404"}]}
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -106,5 +106,44 @@ describe "Swagger stuff" do
         end
       end
     end
+
+    context "v2.0" do
+      let(:version) { "2.0" }
+      ::Insights::API::Common::OpenApi::Docs.instance["2.0"].definitions.each do |definition_name, _schema|
+        next if definition_name.in?(["CollectionLinks", "CollectionMetadata"])
+
+        definition_name = definition_name.delete_suffix(/Collection\z/, "").singularize
+
+        it "#{definition_name} matches the JSONSchema" do
+          expect(send(definition_name.underscore).as_json(:prefixes => ["api/v1x0/#{definition_name.underscore}"])).to match_json_schema("2.0", definition_name)
+        end
+      end
+    end
+
+    context "v3.0" do
+      let(:version) { "3.0" }
+      ::Insights::API::Common::OpenApi::Docs.instance["3.0"].definitions.each do |definition_name, _schema|
+        next if definition_name.in?(["CollectionLinks", "CollectionMetadata"])
+
+        definition_name = definition_name.delete_suffix(/Collection\z/, "").singularize
+
+        it "#{definition_name} matches the JSONSchema" do
+          expect(send(definition_name.underscore).as_json(:prefixes => ["api/v3x0/#{definition_name.underscore}"])).to match_json_schema("3.0", definition_name)
+        end
+      end
+    end
+
+    context "v3.1" do
+      let(:version) { "3.1" }
+      ::Insights::API::Common::OpenApi::Docs.instance["3.1"].definitions.each do |definition_name, _schema|
+        next if definition_name.in?(["CollectionLinks", "CollectionMetadata"])
+
+        definition_name = definition_name.delete_suffix(/Collection\z/, "").singularize
+
+        it "#{definition_name} matches the JSONSchema" do
+          expect(send(definition_name.underscore).as_json(:prefixes => ["api/v3x1/#{definition_name.underscore}"])).to match_json_schema("3.1", definition_name)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
PR for adding all the endpoints for `ApplicationType` `MetaData` models.

After thinking it through, we don't want these to be editable in any way (except maybe /internal, but they're gonna be public anyway), so I'm going to add some seeding for the app meta data type. 

\# TODO:
- [x] index
~- [x] post~
~- [x] patch~
~- [x] delete~
- [x] openapi working with all
- [x] tests