### PR TITLE
Add 'app_creation_workflow' enumerated string to Source to track creation type

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -11,7 +11,7 @@ class Source < ApplicationRecord
 
   attribute :availability_status, :string
   validates :availability_status, :inclusion => { :in => %w[available partially_available unavailable] }, :allow_nil => true
-  validates :app_creation_workflow, :inclusion => {:in => %w[paranoid semi-trust trust]}
+  validates :app_creation_workflow, :inclusion => {:in => %w[manual_configuration account_authorization]}
 
   belongs_to :source_type
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -11,6 +11,7 @@ class Source < ApplicationRecord
 
   attribute :availability_status, :string
   validates :availability_status, :inclusion => { :in => %w[available partially_available unavailable] }, :allow_nil => true
+  validates :app_creation_workflow, :inclusion => {:in => %w[paranoid semi-trust trust]}
 
   belongs_to :source_type
 

--- a/db/migrate/20210125173413_add_app_creation_workflow_to_sources.rb
+++ b/db/migrate/20210125173413_add_app_creation_workflow_to_sources.rb
@@ -1,5 +1,5 @@
 class AddAppCreationWorkflowToSources < ActiveRecord::Migration[5.2]
   def change
-    add_column :sources, :app_creation_workflow, :string, :default => "paranoid"
+    add_column :sources, :app_creation_workflow, :string, :default => "manual_configuration"
   end
 end

--- a/db/migrate/20210125173413_add_app_creation_workflow_to_sources.rb
+++ b/db/migrate/20210125173413_add_app_creation_workflow_to_sources.rb
@@ -1,0 +1,5 @@
+class AddAppCreationWorkflowToSources < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sources, :app_creation_workflow, :string, :default => "paranoid"
+  end
+end

--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -2098,6 +2098,14 @@
       "Source": {
         "type": "object",
         "properties": {
+          "app_creation_workflow": {
+            "type": "string",
+            "enum": [
+              "paranoid",
+              "semi-trust",
+              "trust"
+            ]
+          },
           "availability_status": {
             "type": "string"
           },

--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -2101,9 +2101,8 @@
           "app_creation_workflow": {
             "type": "string",
             "enum": [
-              "paranoid",
-              "semi-trust",
-              "trust"
+              "manual_configuration",
+              "account_authorization"
             ]
           },
           "availability_status": {


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-11657

Adding this field to track what type of workflow we should use when creating applications off of said source. It's an enum (in the openapi and in the rails model validation) of `%w(trust semi-trust paranoid)`.
