### PR TITLE
Add support for skipping specified sourcetypes/applicationtypes

### DIFF
--- a/app/models/concerns/seeding_concern.rb
+++ b/app/models/concerns/seeding_concern.rb
@@ -7,12 +7,15 @@ module SeedingConcern
     def seed
       logger.info("Seeding #{name}...")
       seeds = YAML.load_file(Rails.root.join("db/seeds/#{table_name}.yml"))
+      excluded_types = ENV.fetch("#{to_s.upcase}_SKIP_LIST", "").split(",")
 
       transaction do
         records = all.index_by(&seed_key)
 
         seeds.each do |key, attributes|
-          if (r = records.delete(key))
+          if excluded_types.include?(key)
+            logger.info("Skipping #{key}")
+          elsif (r = records.delete(key))
             logger.info("Updating #{key}")
             r.update!(attributes)
           else


### PR DESCRIPTION
This is so we can skip passing along google cloud to prod.

This will require the e2e-deploy PR to be merged as well as the app-interface deploy.yml updated to skip google-cloud source type. 

DEPENDS ON:
- [ ] https://github.com/RedHatInsights/e2e-deploy/pull/2761
