### PR TITLE
Revert "Merge pull request #320 from slemrmartin/seed-excluded-google"

### DIFF
--- a/app/models/concerns/seeding_concern.rb
+++ b/app/models/concerns/seeding_concern.rb
@@ -14,7 +14,6 @@ module SeedingConcern
 
         seeds.each do |key, attributes|
           if excluded_types.include?(key)
-            records.delete(key)
             logger.info("Skipping #{key}")
           elsif (r = records.delete(key))
             logger.info("Updating #{key}")


### PR DESCRIPTION
This reverts commit b9fb81ccf8cf733a3e438a0abcfb65f72e199e6b, reversing
changes made to b61783c5aa55227f1e1e6e2f6a2618473c013c5e.

So basically this reversed my change, we call `.destroy` on each type _left in the hash_ at the end, here: https://github.com/RedHatInsights/sources-api/blob/3d1681a75646866e896297595fb50f9550da5817/app/models/concerns/seeding_concern.rb#L28-L29

By deleting it from the hash (this PR) it doesn't get cleaned up from the db. After removing that line in CI I get the successful deletion:
```
{"@timestamp":"2021-02-17T18:43:40.129493 ","hostname":"sources-api-1099-wr8lr","pid":148,"tid":"2b14697bd95c","level":"info","message":"Deleting google"}
```
