### PR TITLE
Missing => in rescue

### DIFF
--- a/app/controllers/api/v1/sources_controller.rb
+++ b/app/controllers/api/v1/sources_controller.rb
@@ -43,7 +43,7 @@ module Api
           )
 
           logger.debug("Publishing message for Source#availability_check [#{{"source_id" => source.id, "topic" => topic}}]...Complete")
-        rescue e
+        rescue => e
           logger.error("Hit error attempting to publish [#{{"source_id" => source.id, "topic" => topic}}] during Source#availability_check: #{e.message}")
         end
 


### PR DESCRIPTION
This was causing an error if Kafka had issues, this leg of the code
would get executed and fail.

```
{"@timestamp":"2021-02-18T19:19:27.584275 ","hostname":"sources-api-1104-8wpvz","pid":34,"tid":"2abee0fb98d8","level":"err","message":"NameError: undefined local variable or method `e' for #<Api::V1x0::SourcesController:0x0000557dc0bd2a20>\n/opt/sources-api/app/controllers/api/v1/sources_controller.rb:46:in `rescue in check_availability'\n/opt/sources-api/app/controllers/api/v1/sources_controller.rb:29:in `check_availability'\n/usr/share/gems/gems/actionpack-5.2.4.5/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'\n/usr/share/gems/gems/actionpack-5.2.4.5/lib/abstract_controller/base.rb:194:in `process_action'\n/usr/share/gems/gems/actionpack-5.2.4.5/lib/action_controller/metal/rendering.rb:30:
```