### PR TITLE
Lookup the SuperKey authtype rather than assuming it is just "superkey"

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,6 +1,4 @@
 class Application < ApplicationRecord
-  SUPERKEY_WORKFLOW = "account_authorization".freeze
-
   include TenancyConcern
   include EventConcern
   include AvailabilityStatusConcern
@@ -40,10 +38,13 @@ class Application < ApplicationRecord
   end
 
   def superkey_workflow
-    return unless source.app_creation_workflow == SUPERKEY_WORKFLOW
+    return unless source.super_key?
 
-    if source.super_key.nil?
-      update!(:availability_status => "unavailable", :availability_status_error => "Superkey Credential Missing")
+    if source.super_key_credential.nil?
+      update!(
+        :availability_status       => "unavailable",
+        :availability_status_error => "The source is missing credentials for account authorization. Please remove the source and try to add it again / open a ticket to solve this issue."
+      )
       return
     end
 

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -42,6 +42,11 @@ class Application < ApplicationRecord
   def superkey_workflow
     return unless source.app_creation_workflow == SUPERKEY_WORKFLOW
 
+    if source.super_key.nil?
+      update!(:availability_status => "unavailable", :availability_status_error => "Superkey Credential Missing")
+      return
+    end
+
     sk = Sources::SuperKey.new(
       :provider    => source.source_type.name,
       :source_id   => source.id,

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -14,6 +14,7 @@ class Authentication < ApplicationRecord
   validates :availability_status, :inclusion => { :in => %w[available unavailable] }, :allow_nil => true
 
   before_validation :set_source
+  validate :only_one_superkey, :if => proc { source.super_key? }
 
   private
 
@@ -23,5 +24,14 @@ class Authentication < ApplicationRecord
                      else
                        resource.try(:source_id)
                      end
+  end
+
+  def only_one_superkey
+    superkey_authtype = source.source_type.superkey_authtype
+    return unless superkey_authtype && authtype == superkey_authtype
+
+    if source.authentications.any? { |auth| auth.authtype == superkey_authtype }
+      errors.add(:only_one_superkey, "Only one Authentication of #{superkey_authtype} is allowed on the Source.")
+    end
   end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -25,8 +25,9 @@ class Source < ApplicationRecord
     default || endpoints.build(:default => true, :tenant => tenant)
   end
 
+  # finds the superkey authentication tied to the Source
   def super_key
-    authentications.find_by!(:authtype => "superkey")
+    authentications.detect { |a| a.authtype == source_type.superkey_authtype }
   end
 
   def remove_availability_status(source = nil)

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,4 +1,6 @@
 class Source < ApplicationRecord
+  SUPERKEY_WORKFLOW = "account_authorization".freeze
+
   include TenancyConcern
   include EventConcern
   include AvailabilityStatusConcern
@@ -25,8 +27,12 @@ class Source < ApplicationRecord
     default || endpoints.build(:default => true, :tenant => tenant)
   end
 
+  def super_key?
+    app_creation_workflow == SUPERKEY_WORKFLOW
+  end
+
   # finds the superkey authentication tied to the Source
-  def super_key
+  def super_key_credential
     authentications.detect { |a| a.authtype == source_type.superkey_authtype }
   end
 

--- a/app/models/source_type.rb
+++ b/app/models/source_type.rb
@@ -3,4 +3,12 @@ class SourceType < ApplicationRecord
   self.seed_key = :name
 
   has_many :sources
+
+  def superkey_authtype
+    return nil unless schema
+
+    schema.fetch("authentication", [])
+          .detect { |auth| auth["is_superkey"] == true }
+          .try(:[], "type")
+  end
 end

--- a/lib/sources/super_key.rb
+++ b/lib/sources/super_key.rb
@@ -29,7 +29,7 @@ module Sources
 
       Sources::Api::Messaging.send_superkey_create_request(
         :application => @application,
-        :super_key   => src.super_key,
+        :super_key   => src.super_key_credential,
         :provider    => @provider,
         :extra       => extra
       )

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -1,0 +1,21 @@
+require "models/shared/availability_status"
+
+describe Authentication do
+  context "when creating superkey authentication" do
+    before { SourceType.seed }
+
+    let(:amazon) { SourceType.find_by(:name => "amazon") }
+    let!(:source) { create(:source, :source_type => amazon, :app_creation_workflow => Source::SUPERKEY_WORKFLOW) }
+    let!(:authentication) { create(:authentication, :resource => source, :authtype => amazon.superkey_authtype) }
+
+    it "only allows one superkey auth per source" do
+      expect do
+        Authentication.create!(
+          :resource => source,
+          :authtype => amazon.superkey_authtype,
+          :tenant   => source.tenant
+        )
+      end.to raise_error(ActiveRecord::ActiveRecordError)
+    end
+  end
+end


### PR DESCRIPTION
As found in the initial integration by @rvsia and mentioned after merge in #314, instead of setting `:authtype => "superkey"` in the payload it will be better to look up the sourcetype[:authentication] hash and find out which authentication type is the superkey type.

\# TODO:
- [x] update `Source#super_key` method to look up authentication
- [x] update callback to change availability status + error if there is no superkey set + account_authorization in app_creation_workflow
- [x] partition `authentications` array based on new lookup rather than just `:authtype == "superkey"`
- [x] validate on authentication creation that there is only *ONE* superkey authentication per source
