### PR TITLE
Removing status from authentication model

### DIFF
--- a/db/migrate/20210224151150_remove_status_from_authentication.rb
+++ b/db/migrate/20210224151150_remove_status_from_authentication.rb
@@ -1,0 +1,6 @@
+class RemoveStatusFromAuthentication < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :authentications, :status,         :string
+    remove_column :authentications, :status_details, :string
+  end
+end

--- a/public/doc/openapi-3-v1.0.json
+++ b/public/doc/openapi-3-v1.0.json
@@ -1438,13 +1438,6 @@
           "source_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "status": {
-            "example": "valid",
-            "type": "string"
-          },
-          "status_details": {
-            "type": "string"
-          },
           "tenant": {
             "type": "string",
             "readOnly": true

--- a/public/doc/openapi-3-v2.0.json
+++ b/public/doc/openapi-3-v2.0.json
@@ -1681,13 +1681,6 @@
           "source_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "status": {
-            "example": "valid",
-            "type": "string"
-          },
-          "status_details": {
-            "type": "string"
-          },
           "username": {
             "example": "user@example.com",
             "type": "string"

--- a/public/doc/openapi-3-v3.0.json
+++ b/public/doc/openapi-3-v3.0.json
@@ -1690,13 +1690,6 @@
           "source_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "status": {
-            "example": "valid",
-            "type": "string"
-          },
-          "status_details": {
-            "type": "string"
-          },
           "username": {
             "example": "user@example.com",
             "type": "string"

--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -1877,13 +1877,6 @@
           "source_id": {
             "$ref": "#/components/schemas/ID"
           },
-          "status": {
-            "example": "valid",
-            "type": "string"
-          },
-          "status_details": {
-            "type": "string"
-          },
           "username": {
             "example": "user@example.com",
             "type": "string"


### PR DESCRIPTION
Adding migration for removing `status` and `status_details` columns from `authentications` table. 
```
    remove_column :authentications, :status,         :string
    remove_column :authentications, :status_details, :string
```
Based on https://github.com/RedHatInsights/sources-api/issues/317

Edit: removing the `status` and `status_details` instead of the `availability_status` related attributes based on the @lindgrenj6 and @rvsia comments.