### PR TITLE
Add new `Bulk.create` event when `/bulk_create` is called.

### DIFF
--- a/app/controllers/api/v3x1/bulk_create_controller.rb
+++ b/app/controllers/api/v3x1/bulk_create_controller.rb
@@ -23,6 +23,9 @@ module Api
           end
         end
 
+        # raise a single bulk-create event with the types + array of id's
+        raise_event("Bulk.create", bulk.output.transform_values { |val| val&.map(&:id) }.as_json)
+
         render :status => 201, :json => bulk.output
       end
     end

--- a/spec/requests/api/v3.1/bulk_create_spec.rb
+++ b/spec/requests/api/v3.1/bulk_create_spec.rb
@@ -25,7 +25,7 @@ describe "v3.1 - /bulk_create" do
     context "with source + application" do
       context "with string apptype" do
         it "creates the resources" do
-          expect(Sources::Api::Events).to receive(:raise_event).twice
+          expect(Sources::Api::Events).to receive(:raise_event).exactly(3).times
 
           post collection_path,
                :headers => headers,
@@ -47,7 +47,7 @@ describe "v3.1 - /bulk_create" do
 
       context "with id apptype" do
         it "creates the resources" do
-          expect(Sources::Api::Events).to receive(:raise_event).twice
+          expect(Sources::Api::Events).to receive(:raise_event).exactly(3).times
 
           post collection_path,
                :headers => headers,
@@ -69,7 +69,7 @@ describe "v3.1 - /bulk_create" do
 
       context "with multiple applications" do
         it "creates the resources" do
-          expect(Sources::Api::Events).to receive(:raise_event).thrice
+          expect(Sources::Api::Events).to receive(:raise_event).exactly(4).times
 
           post collection_path,
                :headers => headers,
@@ -96,7 +96,7 @@ describe "v3.1 - /bulk_create" do
 
     context "with source + endpoint" do
       it "creates the resources" do
-        expect(Sources::Api::Events).to receive(:raise_event).twice
+        expect(Sources::Api::Events).to receive(:raise_event).exactly(3).times
 
         post collection_path,
              :headers => headers,
@@ -118,7 +118,7 @@ describe "v3.1 - /bulk_create" do
 
     context "with source + application + authentication" do
       it "creates the resources" do
-        expect(Sources::Api::Events).to receive(:raise_event).exactly(4).times
+        expect(Sources::Api::Events).to receive(:raise_event).exactly(5).times
 
         post collection_path,
              :headers => headers,
@@ -151,7 +151,7 @@ describe "v3.1 - /bulk_create" do
 
     context "with source + endpoint + authentication" do
       it "creates the resources" do
-        expect(Sources::Api::Events).to receive(:raise_event).thrice
+        expect(Sources::Api::Events).to receive(:raise_event).exactly(4).times
 
         post collection_path,
              :headers => headers,


### PR DESCRIPTION
cc @dccurtis :)

Raising a new event on `/bulk_create`, the older `#{model}.create` messages will still go out for backwards compatibility (mostly for topo services), but there will now also be a new `Bulk.create` message published.

The body of the message is an object of the types + id's that were created. Example:

If one posts a body with:
```
{
    "sources": [(source fields for creation)...],
    "applications": [(app fields for creation)...]
}
```
The message will be:
```
{
    "sources": {"1", "2", "3"},
    "applications": {"4", "5", "6"}
}
```

where the numbers in the message are the id's of what was created. This should make it easier to know which sources/applications/authentications are tied together. 
