### PR TITLE
fix missed method call name in superkey service class

### DIFF
--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -40,7 +40,7 @@ module Sources
 
         payload = {
           :tenant_id       => application.tenant.external_tenant,
-          :super_key       => application.source.super_key.id.to_s,
+          :super_key       => application.source.super_key_credential.id.to_s,
           :guid            => application.superkey_data["guid"],
           :provider        => application.superkey_data["provider"],
           :steps_completed => application.superkey_data["steps"],


### PR DESCRIPTION
Forgot to update this service class with the new method name, need this for teardown to work properly.
