### PR TITLE
Configurable DB Pool size

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -48,6 +48,8 @@ objects:
         env:
         - name: APP_NAME
           value: ${APP_NAME}
+        - name: DB_POOL_SIZE
+          value: ${DB_POOL_SIZE}
         - name: RAILS_LOG_LEVEL
           value: ${LOG_LEVEL}
           # TODO: It never can be blank!
@@ -138,6 +140,10 @@ parameters:
   value: 500m
 - name: CPU_REQUEST
   value: 100m
+- name: DB_POOL_SIZE
+  displayName: Database Pool size
+  description: Database pool configuration in DATABASE_URL env
+  value: "5"
 - name: ENCRYPTION_KEY
   displayName: Encryption Key (Ephemeral)
   required: true

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -41,6 +41,6 @@ safeuser=$(urlescape ${DATABASE_USER})
 safepass=$(urlescape ${DATABASE_PASSWORD})
 
 export RAILS_ENV=production
-export DATABASE_URL="postgresql://${safeuser}:${safepass}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?encoding=utf8&pool=5&wait_timeout=5"
+export DATABASE_URL="postgresql://${safeuser}:${safepass}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?encoding=utf8&pool=${DB_POOL_SIZE:-5}&wait_timeout=5"
 
 exec ${@}


### PR DESCRIPTION
Makes db pool size configurable by ENV. Defaults to 5 (current value)

- [x] **depends on** https://github.com/RedHatInsights/e2e-deploy/pull/2831
---

[RHCLOUD-12757](https://issues.redhat.com/browse/RHCLOUD-12757)