### PR TITLE
Add `superkey_data` field to ignore list

### DIFF
--- a/app/models/concerns/availability_status_concern.rb
+++ b/app/models/concerns/availability_status_concern.rb
@@ -13,7 +13,8 @@ module AvailabilityStatusConcern
     "last_available_at",
     "last_checked_at",
     "updated_at",
-    "name"
+    "name",
+    "superkey_data"
   ].freeze
 
   def update_status


### PR DESCRIPTION
So in debugging why the superkey worker wasn't able to PATCH the availability status back to the Application + Source objects (it was just always nil), I found out that if the changeset includes availability status AND anything else, it removes said settings. 

This is a problem for SuperKey worker because we patch back metadata to store in the `:extra` column. So here I added the superkey_data to the payload in order for the patch to work. 

---

This does bring up a bigger discussion though - should we change this logic to the opposite, e.g. "if any of these fields change -> nuke the status" rather than ignoring certain fields and updating if anything ELSE is included. 
