### PR TITLE
Migrate so any dangling Authentications with source_id unset get set

### DIFF
--- a/db/migrate/20210308170013_link_authentications_to_sources.rb
+++ b/db/migrate/20210308170013_link_authentications_to_sources.rb
@@ -1,0 +1,12 @@
+class LinkAuthenticationsToSources < ActiveRecord::Migration[5.2]
+  def change
+    Authentication.where(:source_id => nil).each do |auth|
+      parent = auth.resource_type.constantize.send(:find, auth.resource_id)
+
+      Rails.logger.info("Linking Authentication #{auth.id} to #{resource_type} #{resource_id}'s parent Source")
+      auth.update!(:source_id => parent.source_id)
+    rescue => e
+      Rails.logger.warn("Error trying to find parent for Authentication #{auth.id}: #{e}")
+    end
+  end
+end


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-12814

A user realized there could be instances where `Authentication#source_id` is unset due to us not running a migration when we initially added the `source_id` column to Authentications.


Note this does not fix the fact that there DEFINITELY are dangling authentications out there - e.g. in CI there are like 200+ that are pointing to an endpoint/application that just doesn't exist. 
