### PR TITLE
APP SRE build for CI cluster

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -21,5 +21,8 @@ docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
 docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+# Backward compatibility with CI/QA
+docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:latest"
+docker --config="$DOCKER_CONF" push "${IMAGE}:latest"
 docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:qa"
 docker --config="$DOCKER_CONF" push "${IMAGE}:qa"


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/318

APP SRE build pipeline must create quay :latest tag for CI cluster

---

[RHCLOUD-12241](https://issues.redhat.com/browse/RHCLOUD-12241)