### PR TITLE
Use model SourceType in migration RenameSatelliteInitialValue

### DIFF
--- a/db/migrate/20200422154616_rename_satellite_initial_value.rb
+++ b/db/migrate/20200422154616_rename_satellite_initial_value.rb
@@ -1,4 +1,6 @@
 class RenameSatelliteInitialValue < ActiveRecord::Migration[5.2]
+  class SourceType < ActiveRecord::Base; end
+
   def up
     rename("sattelite", "satellite")
   end


### PR DESCRIPTION
This change keeps migrations independent  on `app/models`. 
