### PR TITLE
raise event for ApplicationAuthentication resources created

### DIFF
--- a/app/controllers/api/v3x1/bulk_create_controller.rb
+++ b/app/controllers/api/v3x1/bulk_create_controller.rb
@@ -6,11 +6,20 @@ module Api
         authorize(Source.new)
         bulk = Sources::BulkAssembly.new(params_for_create).process
 
-        bulk.output.each do |type, created|
-          next if created.nil?
-
-          created.each do |e|
+        # source, endpoints, applications all can be raised normally
+        [:sources, :endpoints, :applications].each do |type|
+          bulk.output[type]&.each do |e|
             raise_event("#{type.to_s.capitalize.singularize}.create", e.as_json)
+          end
+        end
+
+        # authentications are special since they have a "hidden"
+        # ApplicationAuthentication subresource
+        bulk.output[:authentications]&.each do |auth|
+          raise_event("Authentication.create", auth.as_json)
+
+          auth.application_authentications.each do |app_auth|
+            raise_event("ApplicationAuthentication.create", app_auth.as_json)
           end
         end
 

--- a/spec/requests/api/v3.1/bulk_create_spec.rb
+++ b/spec/requests/api/v3.1/bulk_create_spec.rb
@@ -118,7 +118,7 @@ describe "v3.1 - /bulk_create" do
 
     context "with source + application + authentication" do
       it "creates the resources" do
-        expect(Sources::Api::Events).to receive(:raise_event).thrice
+        expect(Sources::Api::Events).to receive(:raise_event).exactly(4).times
 
         post collection_path,
              :headers => headers,


### PR DESCRIPTION
2 bugs here:
https://issues.redhat.com/browse/RHCLOUD-12783
https://issues.redhat.com/browse/RHCLOUD-12870

cc @zsadeh 

Forgot to raise the event for the `ApplicationAuthentication` resources created during bulk_create, which was making it so superkey resources for subscription watch weren't getting registered.

This fixes that. 
