### PR TITLE
Allow sending raise_event only for Source#update

### DIFF
--- a/app/controllers/api/v1/mixins/update_mixin.rb
+++ b/app/controllers/api/v1/mixins/update_mixin.rb
@@ -7,9 +7,7 @@ module Api
           authorize(record)
 
           record.update!(params_for_update)
-
-          ignore_raise_event = record.try(:ignore_raise_event_for?, params_for_update.keys)
-          raise_event_if(ignore_raise_event, "#{model}.update", record.to_json)
+          record.raise_event_for_update(params_for_update.keys)
 
           head :no_content
         end

--- a/app/controllers/api/v1/mixins/update_mixin.rb
+++ b/app/controllers/api/v1/mixins/update_mixin.rb
@@ -7,7 +7,10 @@ module Api
           authorize(record)
 
           record.update!(params_for_update)
-          raise_event("#{model}.update", record.as_json)
+
+          ignore_raise_event = record.try(:ignore_raise_event_for?, params_for_update.keys)
+          raise_event_if(ignore_raise_event, "#{model}.update", record.to_json)
+
           head :no_content
         end
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,6 +74,10 @@ class ApplicationController < ActionController::API
     send("api_#{version}_#{endpoint}_url", instance.id)
   end
 
+  def raise_event_if(ignore_raise_event, event, payload)
+    raise_event(event, payload) unless ignore_raise_event
+  end
+
   def raise_event(event, payload)
     headers = Insights::API::Common::Request.current_forwardable
     logger.debug("publishing message to topic \"platform.sources.event-stream\"...")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,14 +75,14 @@ class ApplicationController < ActionController::API
   end
 
   def raise_event_if(ignore_raise_event, event, payload)
-    raise_event(event, payload) unless ignore_raise_event
+    return if ignore_raise_event
+
+    headers = Insights::API::Common::Request.current_forwardable
+    Sources::Api::Events.raise_event_with_logging(event, payload, headers)
   end
 
   def raise_event(event, payload)
-    headers = Insights::API::Common::Request.current_forwardable
-    logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
-    Sources::Api::Events.raise_event(event, payload, headers)
-    logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
+    raise_event_if(false, event, payload)
   end
 
   def params_for_create

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -18,12 +18,6 @@ class Application < ApplicationRecord
   after_create :superkey_workflow
   after_destroy :superkey_workflow
 
-  IGNORE_RAISE_EVENT_ATTRIBUTES_LIST = %i[availability_status availability_status_error].freeze
-
-  def ignore_raise_event_for?(attributes)
-    (IGNORE_RAISE_EVENT_ATTRIBUTES_LIST & attributes.map(&:to_sym)).present?
-  end
-
   def remove_availability_status!
     remove_availability_status
     save!

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -18,6 +18,12 @@ class Application < ApplicationRecord
   after_create :superkey_workflow
   after_destroy :superkey_workflow
 
+  IGNORE_RAISE_EVENT_ATTRIBUTES_LIST = %i[availability_status availability_status_error].freeze
+
+  def ignore_raise_event_for?(attributes)
+    (IGNORE_RAISE_EVENT_ATTRIBUTES_LIST & attributes.map(&:to_sym)).present?
+  end
+
   def remove_availability_status!
     remove_availability_status
     save!

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -20,9 +20,9 @@ module EventConcern
     (IGNORE_RAISE_EVENT_ATTRIBUTES_LIST & attributes.map(&:to_sym)).present?
   end
 
-  def raise_event_for_update(attributes)
+  def raise_event_for_update(attributes, headers = safe_headers)
     condition = ignore_raise_event_for?(attributes)
-    Sources::Api::Events.raise_event_with_logging_if(condition, "#{self.class}.update", as_json, safe_headers)
+    Sources::Api::Events.raise_event_with_logging_if(condition, "#{self.class}.update", as_json, headers)
   end
 
   def raise_event_for_destroy

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -8,7 +8,9 @@ module EventConcern
   IGNORE_RAISE_EVENT_ATTRIBUTES_LIST = %i[availability_status availability_status_error].freeze
 
   IGNORE_RAISE_EVENT_LIST = {
-    "Application"    => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST
+    "Application"    => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST,
+    "Authentication" => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST,
+    "Endpoint"       => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST
   }.freeze
 
   def ignore_raise_event_for?(attributes)
@@ -20,11 +22,11 @@ module EventConcern
 
   def raise_event_for_update(attributes)
     condition = ignore_raise_event_for?(attributes)
-    Sources::Api::Events.raise_event_with_logging_if(condition, "#{self.class}.update", self.as_json, safe_headers)
+    Sources::Api::Events.raise_event_with_logging_if(condition, "#{self.class}.update", as_json, safe_headers)
   end
 
   def raise_event_for_destroy
-    Sources::Api::Events.raise_event_with_logging("#{self.class}.destroy", self.as_json, safe_headers)
+    Sources::Api::Events.raise_event_with_logging("#{self.class}.destroy", as_json, safe_headers)
   end
 
   def safe_headers

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -2,10 +2,10 @@ module EventConcern
   extend ActiveSupport::Concern
 
   included do
-    after_destroy :raise_event, :prepend => true
+    after_destroy :raise_event_for_destroy, :prepend => true
   end
 
-  def raise_event
+  def raise_event_for_destroy
     headers = Insights::API::Common::Request.current_forwardable
 
     Sources::Api::Events.raise_event_with_logging("#{self.class}.destroy", self.as_json, headers)

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -7,8 +7,7 @@ module EventConcern
 
   def raise_event
     headers = Insights::API::Common::Request.current_forwardable
-    logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
-    Sources::Api::Events.raise_event("#{self.class}.destroy", self.as_json, headers)
-    logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
+
+    Sources::Api::Events.raise_event_with_logging("#{self.class}.destroy", self.as_json, headers)
   end
 end

--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -52,7 +52,7 @@ class AvailabilityStatusListener
     options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
 
     object.update!(options)
-    object.raise_event_for_update(options.keys)
+    object.raise_event_for_update(options.keys, event.headers)
   rescue NameError
     Rails.logger.error("Invalid resource_type #{payload["resource_type"]}")
   rescue ActiveRecord::RecordNotFound

--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -52,7 +52,9 @@ class AvailabilityStatusListener
     options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
 
     object.update!(options)
-    Sources::Api::Events.raise_event("#{model_class}.update", object.as_json, event.headers)
+
+    ignore_raise_event = object.try(:ignore_raise_event_for?, options.keys)
+    Sources::Api::Events.raise_event_if(ignore_raise_event, "#{model_class}.update", object.as_json, event.headers)
   rescue NameError
     Rails.logger.error("Invalid resource_type #{payload["resource_type"]}")
   rescue ActiveRecord::RecordNotFound

--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -52,7 +52,7 @@ class AvailabilityStatusListener
     options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
 
     object.update!(options)
-    raise_event("#{model_class}.update", object.as_json, event.headers)
+    Sources::Api::Events.raise_event("#{model_class}.update", object.as_json, event.headers)
   rescue NameError
     Rails.logger.error("Invalid resource_type #{payload["resource_type"]}")
   rescue ActiveRecord::RecordNotFound
@@ -61,12 +61,6 @@ class AvailabilityStatusListener
     Rails.logger.error("Invalid status #{payload["status"]}")
   rescue => e
     Rails.logger.error(["Something is wrong when processing Kafka message: ", e.message, *e.backtrace].join($RS))
-  end
-
-  def raise_event(event, payload, headers)
-    Sources::Api::Events.raise_event(event, payload, headers)
-  rescue => e
-    Rails.logger.error(["Failed to send Kafka message with event type(#{event}): ", e.message, *e.backtrace].join($RS))
   end
 
   def validate_resource_type(model_class)

--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -52,9 +52,7 @@ class AvailabilityStatusListener
     options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
 
     object.update!(options)
-
-    ignore_raise_event = object.try(:ignore_raise_event_for?, options.keys)
-    Sources::Api::Events.raise_event_if(ignore_raise_event, "#{model_class}.update", object.as_json, event.headers)
+    object.raise_event_for_update(options.keys)
   rescue NameError
     Rails.logger.error("Invalid resource_type #{payload["resource_type"]}")
   rescue ActiveRecord::RecordNotFound

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -20,6 +20,14 @@ module Sources
       def self.raise_event_if(condition, event, payload, headers = nil)
         raise_event(event, payload, headers) unless condition
       end
+
+      def self.raise_event_with_logging(event, payload, headers)
+        Rails.logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
+
+        raise_event(event, payload, headers)
+
+        Rails.logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
+      end
     end
   end
 end

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -17,14 +17,20 @@ module Sources
         Messaging.client.publish_topic(publish_opts)
       end
 
-      def self.raise_event_if(condition, event, payload, headers = nil)
-        raise_event(event, payload, headers) unless condition
+      def self.raise_event_with_logging_if(ignore_raise_event, event, payload, headers = nil)
+        return if ignore_raise_event
+
+        with_logging { raise_event(event, payload, headers) }
       end
 
-      def self.raise_event_with_logging(event, payload, headers)
+      def self.raise_event_with_logging(event, payload, headers = nil)
+        with_logging { raise_event(event, payload, headers) }
+      end
+
+      def self.with_logging(&_block)
         Rails.logger.debug("publishing message to topic \"platform.sources.event-stream\"...")
 
-        raise_event(event, payload, headers)
+        yield if block_given?
 
         Rails.logger.debug("publishing message to topic \"platform.sources.event-stream\"...Complete")
       end

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -16,6 +16,10 @@ module Sources
 
         Messaging.client.publish_topic(publish_opts)
       end
+
+      def self.raise_event_if(condition, event, payload, headers = nil)
+        raise_event(event, payload, headers) unless condition
+      end
     end
   end
 end

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -1,10 +1,10 @@
 require "manageiq-messaging"
 
 describe Api::V1::Mixins::UpdateMixin do
-  describe Api::V1x0::SourcesController, :type => :request do
-    include ::Spec::Support::TenantIdentity
+  include ::Spec::Support::TenantIdentity
+  let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
 
-    let(:headers)     { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+  describe Api::V1x0::SourcesController, :type => :request do
     let(:client)      { instance_double("ManageIQ::Messaging::Client") }
 
     before do
@@ -15,12 +15,29 @@ describe Api::V1::Mixins::UpdateMixin do
     it "patch /sources/:id updates a Source" do
       source = create(:source, :name => "abc")
 
+      expect(Sources::Api::Events).to receive(:raise_event).with("Source.update", anything, anything)
+
       patch(api_v1x0_source_url(source.id), :params => {:name => "xyz"}.to_json, :headers => headers)
 
       expect(source.reload.name).to eq("xyz")
 
       expect(response.status).to eq(204)
       expect(response.parsed_body).to be_empty
+    end
+  end
+
+  describe Api::V1x0::ApplicationsController, :type => :request do
+    %i[availability_status availability_status_error].each do |attribute|
+      it "patch /applications/:id updates a Application" do
+        application = create(:application)
+
+        expect(Sources::Api::Events).not_to receive(:raise_event)
+
+        patch(api_v1x0_application_url(application.id), :params => {attribute => "available"}.to_json, :headers => headers)
+
+        expect(response.status).to eq(204)
+        expect(response.parsed_body).to be_empty
+      end
     end
   end
 end

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe AvailabilityStatusListener do
   let(:status)     { "unavailable" }
   let(:reason)     { "host unreachable" }
   let(:now)        { Time.new(2020).utc }
+  let(:headers)    { {"SECRET_HEADER" => "PASSWORD"} }
 
   describe "#subscribe_to_availability_status" do
-    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, event_type, payload, {}, nil, client) }
+    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, event_type, payload, headers, nil, client) }
 
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).with(
@@ -57,6 +58,7 @@ RSpec.describe AvailabilityStatusListener do
           let(:resource_id)   { application.id.to_s }
 
           it "updates availability status and last_available_at" do
+            expect(Sources::Api::Events).to receive(:raise_event_with_logging_if).with(true, anything, anything, headers)
             expect(Sources::Api::Events).not_to receive(:raise_event)
 
             subject.subscribe_to_availability_status

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe AvailabilityStatusListener do
 
         context "Source" do
           it "updates availability status and last_available_at" do
-            expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything, anything)
+            expect(Sources::Api::Events).not_to receive(:raise_event)
 
             subject.subscribe_to_availability_status
 
@@ -74,7 +74,7 @@ RSpec.describe AvailabilityStatusListener do
 
       context "when status is unavailable" do
         it "updates availability status" do
-          expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything, anything)
+          expect(Sources::Api::Events).not_to receive(:raise_event)
 
           subject.subscribe_to_availability_status
 

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -34,18 +34,41 @@ RSpec.describe AvailabilityStatusListener do
       context "when status is available" do
         let(:status) { "available" }
 
-        it "updates availability status and last_available_at" do
-          expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything, anything)
+        context "Source" do
+          it "updates availability status and last_available_at" do
+            expect(Sources::Api::Events).to receive(:raise_event).with("Endpoint.update", anything, anything)
 
-          subject.subscribe_to_availability_status
+            subject.subscribe_to_availability_status
 
-          endpoint.reload
-          expect(endpoint).to have_attributes(
-            :availability_status       => status,
-            :availability_status_error => reason,
-            :last_available_at         => now,
-            :last_checked_at           => now
-          )
+            endpoint.reload
+            expect(endpoint).to have_attributes(
+              :availability_status       => status,
+              :availability_status_error => reason,
+              :last_available_at         => now,
+              :last_checked_at           => now
+            )
+          end
+        end
+
+        context "Application" do
+          let(:application) { create(:application) }
+
+          let(:resource_type) { "application" }
+          let(:resource_id)   { application.id.to_s }
+
+          it "updates availability status and last_available_at" do
+            expect(Sources::Api::Events).not_to receive(:raise_event)
+
+            subject.subscribe_to_availability_status
+
+            application.reload
+            expect(application).to have_attributes(
+              :availability_status       => status,
+              :availability_status_error => reason,
+              :last_available_at         => now,
+              :last_checked_at           => now
+            )
+          end
         end
       end
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -313,6 +313,16 @@ RSpec.describe("v1.0 - Sources") do
         )
       end
 
+      it "update availability status" do
+        expect(Sources::Api::Events).to receive(:raise_event).with("Source.update", anything, anything)
+
+        included_attributes = {"availability_status" => "available"}
+        instance = create(:source, attributes.merge("tenant" => tenant))
+        patch(instance_path(instance.id), :params => included_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(:status => 204, :parsed_body => "")
+      end
+
       it "success: with a partially_available availability_status" do
         included_attributes = { "name" => "availability_source", "availability_status" => "partially_available" }
 

--- a/spec/requests/api/v2.0/applications_spec.rb
+++ b/spec/requests/api/v2.0/applications_spec.rb
@@ -106,7 +106,10 @@ RSpec.describe("v2.0 - Applications") do
 
     context "patch" do
       let(:instance) { create(:application, payload.merge(:tenant => tenant)) }
-      it "success: with a valid id" do
+
+      it "update availability status" do
+        expect(Sources::Api::Events).not_to receive(:raise_event)
+
         new_attributes = {"availability_status" => "available"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
 

--- a/spec/requests/api/v2.0/authentications_spec.rb
+++ b/spec/requests/api/v2.0/authentications_spec.rb
@@ -132,6 +132,16 @@ RSpec.describe("v2.0 - Authentications") do
 
     context "patch" do
       let(:instance) { create(:authentication, payload.merge(:tenant => tenant)) }
+
+      it "update availability status" do
+        expect(Sources::Api::Events).not_to receive(:raise_event)
+
+        included_attributes = {"availability_status" => "available"}
+        patch(instance_path(instance.id), :params => included_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(:status => 204, :parsed_body => "")
+      end
+
       it "success: with a valid id" do
         new_attributes = {"name" => "new name"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v2.0/endpoints_spec.rb
+++ b/spec/requests/api/v2.0/endpoints_spec.rb
@@ -114,6 +114,16 @@ RSpec.describe("v2.0 - Endpoints") do
 
     context "patch" do
       let(:instance) { create(:endpoint, payload.merge(:tenant => tenant)) }
+
+      it "update availability status" do
+        expect(Sources::Api::Events).not_to receive(:raise_event)
+
+        included_attributes = {"availability_status" => "available"}
+        patch(instance_path(instance.id), :params => included_attributes.to_json, :headers => headers)
+
+        expect(response).to have_attributes(:status => 204, :parsed_body => "")
+      end
+
       it "success: with a valid id" do
         new_attributes = {"host" => "example.org"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)


### PR DESCRIPTION
Stop sending `raise_event` for 
`Application#update`, `Endpoint#update` and `Authentication#update` when 
attributes `availability_status` or ` availability_status_error` are present in update request:

```
./api/sources/patch 'applications/1' '{"availability_status":"available"}'
./api/sources/patch 'authentications/1' '{"availability_status":"available"}'
./api/sources/patch 'endpoints/1' '{"availability_status":"available"}'
```

---
https://issues.redhat.com/browse/RHCLOUD-12860
