### PR TITLE
Only raise Application.create events for Superkey sources when complete

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -26,7 +26,7 @@ module Api
         # values for the source, but only the first time after the worker processes the message,
         # from there on we raise the normal update.
         first_time_superkey = (application.source.super_key? && params.try(:[], "extra")&.key?("_superkey"))
-        raise_event_unless(first_time_superkey, "Application.create", application.as_json)
+        raise_event_if(first_time_superkey, "Application.create", application.as_json)
 
         # appending the extra keys in case of _superkey being updated.
         application.raise_event_for_update(params_for_update.keys + params.fetch("extra", {}).keys)

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -4,14 +4,34 @@ module Api
       include Api::V1::Mixins::DestroyMixin
       include Api::V1::Mixins::IndexMixin
       include Api::V1::Mixins::ShowMixin
-      include Api::V1::Mixins::UpdateMixin
 
       def create
         application = Application.new(params_for_create).tap { |app| authorize(app) }
         application.save!
 
-        raise_event("#{model}.create", application.as_json)
-        render :json => application, :status => :created, :location => instance_link(application)
+        # we do not want to raise the create event since the application has
+        # not been processed by the superkey worker.
+        raise_event_if(!application.source.super_key?, "Application.create", application.as_json)
+
+        render :json => application, :status => 201, :location => instance_link(application)
+      end
+
+      def update
+        application = Application.find(params.require(:id))
+        authorize(application)
+
+        application.update!(params_for_update)
+
+        # Here we're raising the create event after the worker has filled in the
+        # values for the source, but only the first time after the worker processes the message,
+        # from there on we raise the normal update.
+        first_time_superkey = (application.source.super_key? && params.try(:[], "extra")&.key?("_superkey"))
+        raise_event_unless(first_time_superkey, "Application.create", application.as_json)
+
+        # appending the extra keys in case of _superkey being updated.
+        application.raise_event_for_update(params_for_update.keys + params.fetch("extra", {}).keys)
+
+        head :no_content
       end
     end
   end

--- a/app/controllers/api/v3x1/bulk_create_controller.rb
+++ b/app/controllers/api/v3x1/bulk_create_controller.rb
@@ -6,11 +6,18 @@ module Api
         authorize(Source.new)
         bulk = Sources::BulkAssembly.new(params_for_create).process
 
-        # source, endpoints, applications all can be raised normally
-        [:sources, :endpoints, :applications].each do |type|
+        # source + endpoints can be raised normally
+        [:sources, :endpoints].each do |type|
           bulk.output[type]&.each do |e|
             raise_event("#{type.to_s.capitalize.singularize}.create", e.as_json)
           end
+        end
+
+        # applications only get raised if they're not superkey applications
+        bulk.output[:applications]&.each do |app|
+          # we do not want to raise the create event since the application has
+          # not been processed by the superkey worker.
+          raise_event_unless(!app.source.super_key?, "Application.create", app.as_json)
         end
 
         # authentications are special since they have a "hidden"

--- a/app/controllers/api/v3x1/bulk_create_controller.rb
+++ b/app/controllers/api/v3x1/bulk_create_controller.rb
@@ -17,7 +17,7 @@ module Api
         bulk.output[:applications]&.each do |app|
           # we do not want to raise the create event since the application has
           # not been processed by the superkey worker.
-          raise_event_unless(!app.source.super_key?, "Application.create", app.as_json)
+          raise_event_if(!app.source.super_key?, "Application.create", app.as_json)
         end
 
         # authentications are special since they have a "hidden"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,19 +74,15 @@ class ApplicationController < ActionController::API
     send("api_#{version}_#{endpoint}_url", instance.id)
   end
 
-  def raise_event_if(ignore_raise_event, event, payload)
-    return if ignore_raise_event
+  def raise_event_if(raise_event_allowed, event, payload)
+    return unless raise_event_allowed
 
     headers = Insights::API::Common::Request.current_forwardable
     Sources::Api::Events.raise_event_with_logging(event, payload, headers)
   end
 
-  def raise_event_unless(ignore_raise_event, event, payload)
-    raise_event_if(!ignore_raise_event, event, payload)
-  end
-
   def raise_event(event, payload)
-    raise_event_if(false, event, payload)
+    raise_event_if(true, event, payload)
   end
 
   def params_for_create

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -81,6 +81,10 @@ class ApplicationController < ActionController::API
     Sources::Api::Events.raise_event_with_logging(event, payload, headers)
   end
 
+  def raise_event_unless(ignore_raise_event, event, payload)
+    raise_event_if(!ignore_raise_event, event, payload)
+  end
+
   def raise_event(event, payload)
     raise_event_if(false, event, payload)
   end

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -8,7 +8,7 @@ module EventConcern
   IGNORE_RAISE_EVENT_ATTRIBUTES_LIST = %i[availability_status availability_status_error].freeze
 
   IGNORE_RAISE_EVENT_LIST = {
-    "Application"    => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST,
+    "Application"    => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST + %i[_superkey],
     "Authentication" => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST,
     "Endpoint"       => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST
   }.freeze
@@ -17,7 +17,7 @@ module EventConcern
     ignore_attribute_list = IGNORE_RAISE_EVENT_LIST[self.class.name]
     return false unless ignore_attribute_list
 
-    (IGNORE_RAISE_EVENT_ATTRIBUTES_LIST & attributes.map(&:to_sym)).present?
+    (ignore_attribute_list & attributes.map(&:to_sym)).present?
   end
 
   def raise_event_for_update(attributes, headers = safe_headers)

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -13,15 +13,15 @@ module EventConcern
     "Endpoint"       => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST
   }.freeze
 
-  def ignore_raise_event_for?(attributes)
+  def raise_event_allowed?(attributes)
     ignore_attribute_list = IGNORE_RAISE_EVENT_LIST[self.class.name]
-    return false unless ignore_attribute_list
+    return true unless ignore_attribute_list
 
-    (ignore_attribute_list & attributes.map(&:to_sym)).present?
+    (ignore_attribute_list & attributes.map(&:to_sym)).empty?
   end
 
   def raise_event_for_update(attributes, headers = safe_headers)
-    condition = ignore_raise_event_for?(attributes)
+    condition = raise_event_allowed?(attributes)
     Sources::Api::Events.raise_event_with_logging_if(condition, "#{self.class}.update", as_json, headers)
   end
 

--- a/lib/sources/api/events.rb
+++ b/lib/sources/api/events.rb
@@ -17,8 +17,8 @@ module Sources
         Messaging.client.publish_topic(publish_opts)
       end
 
-      def self.raise_event_with_logging_if(ignore_raise_event, event, payload, headers = nil)
-        return if ignore_raise_event
+      def self.raise_event_with_logging_if(raise_event, event, payload, headers = nil)
+        return unless raise_event
 
         with_logging { raise_event(event, payload, headers) }
       end

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe AvailabilityStatusListener do
           let(:resource_id)   { application.id.to_s }
 
           it "updates availability status and last_available_at" do
-            expect(Sources::Api::Events).to receive(:raise_event_with_logging_if).with(true, anything, anything, headers)
+            expect(Sources::Api::Events).to receive(:raise_event_with_logging_if).with(false, anything, anything, headers)
             expect(Sources::Api::Events).not_to receive(:raise_event)
 
             subject.subscribe_to_availability_status

--- a/spec/requests/api/v3.1/bulk_create_spec.rb
+++ b/spec/requests/api/v3.1/bulk_create_spec.rb
@@ -92,6 +92,19 @@ describe "v3.1 - /bulk_create" do
           expect(apps.map { |x| x["application_type_id"].to_i }).to match_array([costapp.id, swatchapp.id])
         end
       end
+
+      context "with superkey sources" do
+        let(:superkey_source) { {:sources => [{:name => "testsksource", :source_type_name => "amazon", :app_creation_workflow => "account_authorization"}]} }
+
+        it "does not raise an application create message" do
+          expect(Sources::Api::Events).to receive(:raise_event).once
+          post collection_path,
+               :headers => headers,
+               :params  => superkey_source.merge!(
+                 :applications => [{:application_type_name => costapp.name, :source_name => "testsksource"}]
+               ).to_json
+        end
+      end
     end
 
     context "with source + endpoint" do


### PR DESCRIPTION
During the integration process for superkey, I'm finding that ordering of messages is the biggest problem faced.

So I'm reworking to only raise the `Application.create` event once the superkey worker posts back. It's complicated logic, but it's necessary to make sure that the events go out in the right order:

1. `Source.create`
2. `Application.create`
3. `Authentication.create`
4. `ApplicationAuthentication.create`

\# TODO:
- [x] tests