### PR TITLE
Clowder rename + PGSSLMODE variable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 # Parser for Clowder config in ENV['ACG_CONFIG'] path
-gem 'clowder-common-ruby',  '~> 0.2.1'
+gem 'clowder-common-ruby',  '~> 0.2.2'
 gem 'cloudwatchlogger',     '~> 0.2.1'
 gem 'insights-api-common',  '~> 5.0'
 gem 'jbuilder',             '~> 2.0'

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1,25 +1,25 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: sources
+  name: sources-api
 objects:
 - apiVersion: v1
   kind: Secret # For ephemeral/local environment
   metadata:
     name: sources-api-secrets
     labels:
-      app: sources
+      app: sources-api
   stringData:
     encryption-key: "${ENCRYPTION_KEY}"
     secret-key: "${SECRET_KEY}"
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: sources
+    name: sources-api
   spec:
     envName: ${ENV_NAME}
     deployments:
-    - name: api
+    - name: svc
       minReplicas: ${{MIN_REPLICAS}}
       webServices:
         public:
@@ -63,12 +63,8 @@ objects:
             secretKeyRef:
               name: sources-api-secrets
               key: encryption-key
-        - name: METRICS_PORT
-          value: ${METRICS_PORT}
         - name: PATH_PREFIX
           value: ${PATH_PREFIX}
-        - name: PGSSLMODE
-          value: ${PGSSLMODE}
         - name: SECRET_KEY_BASE
           valueFrom:
             secretKeyRef:
@@ -127,8 +123,8 @@ objects:
   metadata:
     name: sources-api-transitional
     labels:
-      app: sources
-      pod: sources-api
+      app: sources-api
+      pod: sources-api-svc
   spec:
     ports:
     - port: 8080
@@ -136,7 +132,7 @@ objects:
       targetPort: 8000
       name: weblegacy
     selector:
-      pod: sources-api
+      pod: sources-api-svc
 parameters:
 - description: Application name to be used in request paths.
   displayName: Application Name

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -17,6 +17,7 @@ else
   puts data['database']['username']
   puts data['database']['password']
   puts data['database']['name']
+  puts data['database']['sslMode']
   puts data['webPort']
   puts data['database']['rdsCa']
 EOF
@@ -29,11 +30,12 @@ EOF
   DATABASE_USER=${CONFIG_VALUES[2]}
   DATABASE_PASSWORD=${CONFIG_VALUES[3]}
   DATABASE_NAME=${CONFIG_VALUES[4]}
+  export PGSSLMODE=${CONFIG_VALUES[5]}
 
-  export WEB_PORT=${CONFIG_VALUES[5]}
+  export WEB_PORT=${CONFIG_VALUES[6]}
 
-  if [[ ! -z ${CONFIG_VALUES[6]} ]]; then
-    export PGSSLROOTCERT=${CONFIG_VALUES[6]}
+  if [[ ! -z ${CONFIG_VALUES[7]} ]]; then
+    export PGSSLROOTCERT=${CONFIG_VALUES[7]}
   fi
 fi
 

--- a/lib/sources/api/clowder_config.rb
+++ b/lib/sources/api/clowder_config.rb
@@ -13,11 +13,6 @@ module Sources
             options["awsAccessKeyId"]     = config.logging.cloudwatch.accessKeyId
             options["awsRegion"]          = config.logging.cloudwatch.region
             options["awsSecretAccessKey"] = config.logging.cloudwatch.secretAccessKey
-            options["databaseHostname"]   = config.database.hostname
-            options["databaseName"]       = config.database.name
-            options["databasePassword"]   = config.database.password
-            options["databasePort"]       = config.database.port
-            options["databaseUsername"]   = config.database.username
             options["metricsPort"] = config.metricsPort
             # there might be more brokers but not relevant at this moment
             broker                 = config.kafka.brokers.first
@@ -40,11 +35,6 @@ module Sources
             options["awsAccessKeyId"]     = ENV['CW_AWS_ACCESS_KEY_ID']
             options["awsRegion"]          = "us-east-1"
             options["awsSecretAccessKey"] = ENV['CW_AWS_SECRET_ACCESS_KEY']
-            options["databaseHostname"]   = ENV['DATABASE_HOST']
-            options["databaseName"]       = ENV['DATABASE_NAME']
-            options["databasePassword"]   = ENV['DATABASE_PASSWORD']
-            options["databasePort"]       = ENV['DATABASE_PORT']
-            options["databaseUsername"]   = ENV['DATABASE_USER']
             options["kafkaHost"]          = ENV['QUEUE_HOST'] || "localhost"
             options["kafkaPort"]          = (ENV['QUEUE_PORT'] || "9092").to_i
             options["kafkaTopics"]        = {}


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/318

ClowdApp name (and oc app name) will be equal to the name of the repo
url sources-api has to change (needs to be changed in the app-interface)

also updated clowder-common-ruby to get PGSSLMODE env from cdappconfig.json

---

[RHCLOUD-12241](https://issues.redhat.com/browse/RHCLOUD-12241)