### PR TITLE
Add more validations when creating and destroying SuperKey Authentications

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -20,6 +20,8 @@ class Authentication < ApplicationRecord
 
   def set_source
     self.source_id = if resource.instance_of?(Source)
+                       errors.add(:only_superkey, "sources can have Authentication attached to Source") unless resource.super_key?
+
                        resource_id
                      else
                        resource.try(:source_id)

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -22,6 +22,8 @@ class Source < ApplicationRecord
   validates :name, :presence => true, :allow_blank => false,
             :uniqueness => { :scope => :tenant_id }
 
+  before_destroy :validate_no_applications, :if => -> { super_key? }, :prepend => true
+
   def default_endpoint
     default = endpoints.detect(&:default)
     default || endpoints.build(:default => true, :tenant => tenant)
@@ -46,5 +48,9 @@ class Source < ApplicationRecord
   def remove_availability_status!(source = nil)
     remove_availability_status(source)
     save!
+  end
+
+  def validate_no_applications
+    raise(ActiveRecord::RecordNotDestroyed, "Applications must be removed before destroying parent source") if applications.any?
   end
 end

--- a/spec/lib/sources/bulk_assembly_spec.rb
+++ b/spec/lib/sources/bulk_assembly_spec.rb
@@ -45,7 +45,7 @@ describe Sources::BulkAssembly do
   end
 
   context "when creating a source + subresource" do
-    let(:sourcehash) { {:sources => [{:name => "mysource", :source_type_name => "amazon"}]} }
+    let(:sourcehash) { {:sources => [{:name => "mysource", :source_type_name => "amazon", :app_creation_workflow => Source::SUPERKEY_WORKFLOW}]} }
 
     context "when the request is well formed" do
       context "with a single endpoint" do

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -22,4 +22,12 @@ describe Authentication do
       expect { authentication.update!(:username => "another thing") }.not_to raise_error
     end
   end
+
+  context "when trying to add an authentiction to a non-superkey source" do
+    let(:source) { create(:source) }
+
+    it "does not allow the creation" do
+      expect { Authentication.create!(:resource => source) }.to raise_error(ActiveRecord::RecordInvalid, /Only superkey sources/)
+    end
+  end
 end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -1,4 +1,4 @@
-require "models/shared/availability_status.rb"
+require 'models/shared/availability_status'
 
 describe Source do
   include_context "availability_status_context"
@@ -9,6 +9,17 @@ describe Source do
       res = create(:source, :version => '1')
       res.update!(:availability_status => available_status)
       res
+    end
+  end
+
+  context "when destroying a superkey application" do
+    let!(:source) { create(:source, :app_creation_workflow => Source::SUPERKEY_WORKFLOW) }
+    let!(:app) { create(:application, :source => source) }
+
+    it "doesn't allow destroying the source when there are applications attached" do
+      Insights::API::Common::Request.with_request(default_request) do
+        expect { source.destroy! }.to raise_error(ActiveRecord::RecordNotDestroyed, /Applications must be removed/)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,8 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  config.include RequestHelper
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,0 +1,69 @@
+module RequestHelper
+  DEFAULT_USER = {
+    "entitlements" => {
+      "ansible"          => {
+        "is_entitled" => true
+      },
+      "hybrid_cloud"     => {
+        "is_entitled" => true
+      },
+      "insights"         => {
+        "is_entitled" => true
+      },
+      "migrations"       => {
+        "is_entitled" => true
+      },
+      "openshift"        => {
+        "is_entitled" => true
+      },
+      "smart_management" => {
+        "is_entitled" => true
+      }
+    },
+    "identity"     => {
+      "account_number" => "0369233",
+      "type"           => "User",
+      "auth_type"      => "basic-auth",
+      "user"           => {
+        "username"     => "jdoe",
+        "email"        => "jdoe@acme.com",
+        "first_name"   => "John",
+        "last_name"    => "Doe",
+        "is_active"    => true,
+        "is_org_admin" => false,
+        "is_internal"  => false,
+        "locale"       => "en_US"
+      },
+      "internal"       => {
+        "org_id"    => "3340851",
+        "auth_time" => 6300
+      }
+    }
+  }.freeze
+
+  def encode(val)
+    if val.kind_of?(Hash)
+      hashed = val.stringify_keys
+      Base64.strict_encode64(hashed.to_json)
+    else
+      raise StandardError, "Must be a Hash"
+    end
+  end
+
+  def encoded_user_hash(hash = nil)
+    encode(hash || DEFAULT_USER)
+  end
+
+  def default_headers
+    {'x-rh-identity'            => encoded_user_hash,
+     'x-rh-insights-request-id' => 'gobbledygook'}
+  end
+
+  def original_url
+    "http://example.com"
+  end
+
+  def default_request
+    {:headers => default_headers, :original_url => original_url}
+  end
+end


### PR DESCRIPTION
Fixing: 
- https://issues.redhat.com/browse/RHCLOUD-12897
    This validation specifies that an Authentication can _only_ be attached to a Source if the `Source#app_creation_workflow` is `Source::SUPERKEY_WORKFLOW`

- https://issues.redhat.com/browse/RHCLOUD-13031
    This validation makes it so the user has to disable all of the applications associated with the source before deleting the source, this is just due to the fact that if the Source gets deleted (thus cascade deleting the authentication) there is potential for dangling resources in AWS. 

    This validation ensures that cannot happen, since the superkey worker will have plenty of time to clean up the resources before the Source + SuperKey Auth get deleted in the API



\# TODO: 
- [x] specs
