### PR TITLE
Store the headers from the initial Application create operation to send when the superkey worker fills in the application

### DIFF
--- a/app/controllers/api/v3x1/bulk_create_controller.rb
+++ b/app/controllers/api/v3x1/bulk_create_controller.rb
@@ -17,7 +17,13 @@ module Api
         bulk.output[:applications]&.each do |app|
           # we do not want to raise the create event since the application has
           # not been processed by the superkey worker.
-          raise_event_if(!app.source.super_key?, "Application.create", app.as_json)
+          #
+          # also need to store the headers on create, that way we can send them when the superkey worker posts back.
+          if app.source.super_key?
+            app.update!(:superkey_data => {:headers => Insights::API::Common::Request.current_forwardable})
+          else
+            raise_event("Application.create", app.as_json)
+          end
         end
 
         # authentications are special since they have a "hidden"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,15 +74,15 @@ class ApplicationController < ActionController::API
     send("api_#{version}_#{endpoint}_url", instance.id)
   end
 
-  def raise_event_if(raise_event_allowed, event, payload)
+  def raise_event_if(raise_event_allowed, event, payload, headers = nil)
     return unless raise_event_allowed
 
-    headers = Insights::API::Common::Request.current_forwardable
+    headers ||= Insights::API::Common::Request.current_forwardable
     Sources::Api::Events.raise_event_with_logging(event, payload, headers)
   end
 
-  def raise_event(event, payload)
-    raise_event_if(true, event, payload)
+  def raise_event(event, payload, headers = nil)
+    raise_event_if(true, event, payload, headers)
   end
 
   def params_for_create

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -64,8 +64,8 @@ class Application < ApplicationRecord
 
   def copy_superkey_data
     if extra.key?("_superkey")
-      # pull out the superkey metadata we pass in from the worker
-      self.superkey_data = extra.delete("_superkey")
+      # pull out the superkey metadata we pass in from the worker, it can be nil so we handle that.
+      self.superkey_data&.merge!(extra.delete("_superkey")) || self.superkey_data = extra.delete("_superkey")
     end
   end
 end

--- a/spec/requests/api/v3.1/applications_spec.rb
+++ b/spec/requests/api/v3.1/applications_spec.rb
@@ -196,11 +196,12 @@ RSpec.describe("v3.1 - Applications") do
 
     describe "when updating the application with logic" do
       let(:src) { create(:source, :app_creation_workflow => "account_authorization") }
-      let(:instance) { create(:application, :source => src) }
+      let(:instance) { create(:application, :source => src, :superkey_data => {"headers" => original_headers}) }
+      let(:original_headers) { {"thing" => true} }
       let(:extra_attributes) { {:extra => {:_superkey => {"worked" => true}}} }
 
       it "raises the create event instead of the update event" do
-        expect(Sources::Api::Events).to receive(:raise_event).with("Application.create", any_args).exactly(1).times
+        expect(Sources::Api::Events).to receive(:raise_event).with("Application.create", any_args, original_headers).exactly(1).times
         expect(Sources::Api::Events).not_to receive(:raise_event).with("Application.update", any_args)
 
         patch(instance_path(instance.id), :params => extra_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v3.1/bulk_create_spec.rb
+++ b/spec/requests/api/v3.1/bulk_create_spec.rb
@@ -104,6 +104,17 @@ describe "v3.1 - /bulk_create" do
                  :applications => [{:application_type_name => costapp.name, :source_name => "testsksource"}]
                ).to_json
         end
+
+        it "stores the headers" do
+          post collection_path,
+               :headers => headers,
+               :params  => superkey_source.merge!(
+                 :applications => [{:application_type_name => costapp.name, :source_name => "testsksource"}]
+               ).to_json
+
+          application = Application.find(response.parsed_body["applications"].first["id"])
+          expect(application.superkey_data["headers"]).to have_key("x-rh-identity")
+        end
       end
     end
 


### PR DESCRIPTION
So it turns out the final issue (for cost at least) is that they key off of the headers during create, thats why they aren't able to process the messages anymore since the superkey worker is doing the posting. This is an initial implementation storing stuff on the sources api side. 

I am going to look into sending the headers to the worker and then using it from there so this isn't necessary. 