### PR TITLE
Pass along forwardable headers to superkey worker

### DIFF
--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -31,7 +31,8 @@ module Sources
         client.publish_topic(
           :service => Sources::Api::ClowderConfig.kafka_topic("platform.sources.superkey-requests"),
           :event   => "create_application",
-          :payload => payload
+          :payload => payload,
+          :headers => Insights::API::Common::Request.current_forwardable
         )
       end
 
@@ -51,7 +52,8 @@ module Sources
         client.publish_topic(
           :service => "platform.sources.superkey-requests",
           :event   => "destroy_application",
-          :payload => payload
+          :payload => payload,
+          :headers => Insights::API::Common::Request.current_forwardable
         )
       end
 


### PR DESCRIPTION
Need to pass along the headers in order to make the request back to sources correctly (dummy won't work for all customers)


Needed for https://github.com/RedHatInsights/sources-superkey-worker/pull/22 to work.
