### PR TITLE
Clowder Config parsed by JQ Parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ ENV WORKDIR /opt/sources-api/
 ENV RAILS_ROOT $WORKDIR
 WORKDIR $WORKDIR
 
+# For the clowder config parser
+RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o jq \
+  && chmod +x ./jq && cp jq /usr/bin
+
 COPY docker-assets/librdkafka-1.5.0.tar.gz /tmp/librdkafka.tar.gz
 RUN cd /tmp && tar -xf /tmp/librdkafka.tar.gz && cd librdkafka-1.5.0 && \
     ./configure --prefix=/usr && \

--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -8,45 +8,23 @@ if [[ -z $ACG_CONFIG ]]; then
   DATABASE_NAME="sources_production"
   export WEB_PORT=3000
 else
-  CONFIG_STRING=`ruby<<EOF
-  require 'json'
-  file = File.read(ENV['ACG_CONFIG'])
-  data = JSON.parse(file)
-  puts data['database']['hostname']
-  puts data['database']['port']
-  puts data['database']['username']
-  puts data['database']['password']
-  puts data['database']['name']
-  puts data['database']['sslMode']
-  puts data['webPort']
-EOF
-`
-  CONFIG_VALUES=( $CONFIG_STRING )
+  export DATABASE_HOST=`cat $ACG_CONFIG | jq -r '.database.hostname'`
+  export DATABASE_PORT=`cat $ACG_CONFIG | jq -r '.database.port'`
+  DATABASE_USER=`cat $ACG_CONFIG | jq -r '.database.username'`
+  DATABASE_PASSWORD=`cat $ACG_CONFIG | jq -r '.database.password'`
+  DATABASE_NAME=`cat $ACG_CONFIG | jq -r '.database.name'`
 
-  export DATABASE_HOST=${CONFIG_VALUES[0]}
-  export DATABASE_PORT=${CONFIG_VALUES[1]}
-  DATABASE_USER=${CONFIG_VALUES[2]}
-  DATABASE_PASSWORD=${CONFIG_VALUES[3]}
-  DATABASE_NAME=${CONFIG_VALUES[4]}
-  export PGSSLMODE=${CONFIG_VALUES[5]}
+  sslMode=`cat $ACG_CONFIG | jq -r '.database.sslMode'`
+  if [[ $sslMode != "null" ]]; then
+    export PGSSLMODE=$sslMode
+  fi
 
-  export WEB_PORT=${CONFIG_VALUES[6]}
-
-  cert=`cat $ACG_CONFIG | grep rdsCa | awk '{for(i=2;i<=NF;i++) printf "%s",$i OFS; printf ORS}'`
-  if [[ ! -z $cert ]]; then
+  cert=`cat $ACG_CONFIG | jq -r '.database.rdsCa'`
+  if [[ $cert != "null" ]]; then
     export PGSSLROOTCERT=$cert
   fi
-  echo $CONFIG_STRING
 
-  echo "---"
-
-  cat `echo $ACG_CONFIG`
-
-  echo "----"
-
-  echo "PGSSLMODE: ${PGSSLMODE}"
-  echo "PGSSLROOTCERT: ${PGSSLROOTCERT}"
-  echo " --- "
+  export WEB_PORT=`cat $ACG_CONFIG | jq -r '.webPort'`
 fi
 
 safeuser=$(urlescape ${DATABASE_USER})

--- a/lib/sources/api/clowder_config.rb
+++ b/lib/sources/api/clowder_config.rb
@@ -30,8 +30,6 @@ module Sources
             options["logGroup"]    = config.logging.cloudwatch.logGroup
             options["metricsPath"] = config.metricsPath # PrometheusExporter doesn't support custom path!
             options["webPorts"]    = config.webPort
-
-            puts "Database config: #{config.database.inspect}"
           else
             options["awsAccessKeyId"]     = ENV['CW_AWS_ACCESS_KEY_ID']
             options["awsRegion"]          = "us-east-1"


### PR DESCRIPTION
Following #359. Added `jq` support for easier clowder config parsing in the shell

---

[RHCLOUD-12249](https://issues.redhat.com/browse/RHCLOUD-12249)