### PR TITLE
PGSSLROOTCERT as a path to the cert

### DIFF
--- a/docker-assets/entrypoint
+++ b/docker-assets/entrypoint
@@ -19,9 +19,16 @@ else
     export PGSSLMODE=$sslMode
   fi
 
-  cert=`cat $ACG_CONFIG | jq -r '.database.rdsCa'`
-  if [[ $cert != "null" ]]; then
-    export PGSSLROOTCERT=$cert
+  certString=`cat $ACG_CONFIG | jq -r '.database.rdsCa'`
+
+  certPath="${WORKDIR}rdsca.crt"
+  echo "RDS Cert Path: $certPath"
+  if [[ $certString != "null" ]]; then
+    echo $certString > $certPath
+
+    export PGSSLROOTCERT=$certPath
+  else
+    echo "Hello World" > $certPath
   fi
 
   export WEB_PORT=`cat $ACG_CONFIG | jq -r '.webPort'`


### PR DESCRIPTION
Regarding https://www.postgresql.org/docs/12/libpq-connect.html#LIBPQ-CONNECT-SSLROOTCERT 

PGSSLROOTCERT should be a path (in opposite to clowder config, which offers content)

---

[RHCLOUD-12249](https://issues.redhat.com/browse/RHCLOUD-12249)