### PR TITLE
only update availability status on superkey applications when new_record?

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -41,10 +41,16 @@ class Application < ApplicationRecord
     return unless source.super_key?
 
     if source.super_key_credential.nil?
-      update!(
-        :availability_status       => "unavailable",
-        :availability_status_error => "The source is missing credentials for account authorization. Please remove the source and try to add it again / open a ticket to solve this issue."
-      )
+      # update the availability status on the application if the application was created
+      # on a superkey source and there is _NO_ superkey credential
+      if new_record?
+        update!(
+          :availability_status       => "unavailable",
+          :availability_status_error => "The source is missing credentials for account authorization. Please remove the source and try to add it again / open a ticket to solve this issue."
+        )
+      end
+
+      # can't really do much if we don't have a superkey credential.
       return
     end
 

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -59,4 +59,60 @@ RSpec.describe("Application") do
       end
     end
   end
+
+  describe "superkey" do
+    let!(:source) { create(:source, :app_creation_workflow => "account_authorization") }
+    let!(:apptype) { create(:application_type, :supported_source_types => [source.source_type.name]) }
+    let!(:sk) { instance_double(Sources::SuperKey) }
+
+    let(:client) { instance_double("ManageIQ::Messaging::Client") }
+
+    before do
+      allow(client).to receive(:publish_topic)
+      allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+
+      allow(Sources::SuperKey).to receive(:new).and_return(sk)
+    end
+
+    context "on create" do
+      context "when there is a superkey authentication" do
+        it "runs the superkey workflow" do
+          _auth = Authentication.create!(:resource => source, :tenant => source.tenant, :username => "foo", :password => "bar")
+          expect(sk).to receive(:create).once
+
+          Application.create!(:source => source, :tenant => Tenant.first, :application_type_id => apptype.id)
+        end
+      end
+
+      context "when there is not a superkey authentication" do
+        it "does not run the superkey workflow" do
+          expect(sk).not_to receive(:create)
+
+          Application.create!(:source => source, :tenant => Tenant.first, :application_type_id => apptype.id)
+        end
+      end
+    end
+
+    context "on destroy" do
+      let!(:application) { create(:application, :application_type => apptype, :source => source) }
+
+      context "when there is a superkey authentication" do
+        it "runs the superkey workflow" do
+          _auth = Authentication.create!(:resource => source, :tenant => source.tenant, :username => "foo", :password => "bar")
+          source.reload
+          expect(sk).to receive(:teardown).once
+
+          application.destroy!
+        end
+      end
+
+      context "when there is not a superkey authentication" do
+        it "does not run the superkey workflow" do
+          expect(sk).not_to receive(:teardown)
+
+          application.destroy!
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This appears to be what is causing the error:
```
{
    "errors": [
        {
            "detail": "RuntimeError: Can't modify frozen hash",
            "status": "400"
        }
    ]
}
```

apparently trying to update a subresource's availability status wasn't a good idea on a destroy operation, classic. :facepalm:

cc @zsadeh 

