### PR TITLE
Clowder update for grafana dashboard

### DIFF
--- a/grafana-dashboards/grafana-dashboard-insights-sources.configmap.yaml
+++ b/grafana-dashboards/grafana-dashboard-insights-sources.configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  grafana-dashboard-insights-sources.json: |-
+  grafana-dashboard-insights-sources.json: |
     {
       "annotations": {
         "list": [
@@ -18,7 +18,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "iteration": 1610543988190,
+      "iteration": 1617694616227,
       "links": [],
       "panels": [
         {
@@ -165,7 +165,7 @@ data:
           "pluginVersion": "7.2.1",
           "targets": [
             {
-              "expr": "sum(up{service=\"sources-api\"})",
+              "expr": "sum(up{service=~\"sources-api[-svc]?\"})",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -2115,7 +2115,7 @@ data:
       "timezone": "",
       "title": "Sources",
       "uid": "zxZKNnAMz",
-      "version": 10
+      "version": 11
     }
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/318

Svc name on stage was changed to sources-api-svc (and prod is unchanged).

---

[RHCLOUD-13391](https://issues.redhat.com/browse/RHCLOUD-13391)