### PR TITLE
Add app/clowdapp labels to ClowdApp template

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,6 +16,9 @@ objects:
   kind: ClowdApp
   metadata:
     name: sources-api
+    labels:
+      app: sources
+      clowdapp: sources-api
   spec:
     envName: ${ENV_NAME}
     deployments:


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/318

App-interface ServiceMonitor CRD is configured to "app: sources" label so it's needed to redefine automatic label to be able to scrape metrics.

---

[RHCLOUD-13391](https://issues.redhat.com/browse/RHCLOUD-13391)