### PR TITLE
Re-enable Application/Endpoint availability status update messages

### DIFF
--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -7,10 +7,11 @@ module EventConcern
 
   IGNORE_RAISE_EVENT_ATTRIBUTES_LIST = %i[availability_status availability_status_error].freeze
 
+  # TODO: IGNORE_RAISE_EVENT_ATTRIBUTES_LIST will be added later
   IGNORE_RAISE_EVENT_LIST = {
-    "Application"    => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST + %i[_superkey],
-    "Authentication" => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST,
-    "Endpoint"       => IGNORE_RAISE_EVENT_ATTRIBUTES_LIST
+    "Application"    => %i[_superkey],
+    "Authentication" => [],
+    "Endpoint"       => []
   }.freeze
 
   def raise_event_allowed?(attributes)

--- a/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
+++ b/spec/controllers/api/v1x0/mixins/update_mixin_spec.rb
@@ -25,19 +25,4 @@ describe Api::V1::Mixins::UpdateMixin do
       expect(response.parsed_body).to be_empty
     end
   end
-
-  describe Api::V1x0::ApplicationsController, :type => :request do
-    %i[availability_status availability_status_error].each do |attribute|
-      it "patch /applications/:id updates a Application" do
-        application = create(:application)
-
-        expect(Sources::Api::Events).not_to receive(:raise_event)
-
-        patch(api_v1x0_application_url(application.id), :params => {attribute => "available"}.to_json, :headers => headers)
-
-        expect(response.status).to eq(204)
-        expect(response.parsed_body).to be_empty
-      end
-    end
-  end
 end

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe AvailabilityStatusListener do
 
         context "Source" do
           it "updates availability status and last_available_at" do
-            expect(Sources::Api::Events).not_to receive(:raise_event)
+            expect(Sources::Api::Events).to receive(:raise_event)
 
             subject.subscribe_to_availability_status
 
@@ -58,8 +58,7 @@ RSpec.describe AvailabilityStatusListener do
           let(:resource_id)   { application.id.to_s }
 
           it "updates availability status and last_available_at" do
-            expect(Sources::Api::Events).to receive(:raise_event_with_logging_if).with(false, anything, anything, headers)
-            expect(Sources::Api::Events).not_to receive(:raise_event)
+            expect(Sources::Api::Events).to receive(:raise_event)
 
             subject.subscribe_to_availability_status
 
@@ -76,7 +75,7 @@ RSpec.describe AvailabilityStatusListener do
 
       context "when status is unavailable" do
         it "updates availability status" do
-          expect(Sources::Api::Events).not_to receive(:raise_event)
+          expect(Sources::Api::Events).to receive(:raise_event)
 
           subject.subscribe_to_availability_status
 

--- a/spec/requests/api/v2.0/applications_spec.rb
+++ b/spec/requests/api/v2.0/applications_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe("v2.0 - Applications") do
       let(:instance) { create(:application, payload.merge(:tenant => tenant)) }
 
       it "update availability status" do
-        expect(Sources::Api::Events).not_to receive(:raise_event)
+        expect(Sources::Api::Events).to receive(:raise_event)
 
         new_attributes = {"availability_status" => "available"}
         patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v2.0/authentications_spec.rb
+++ b/spec/requests/api/v2.0/authentications_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe("v2.0 - Authentications") do
       let(:instance) { create(:authentication, payload.merge(:tenant => tenant)) }
 
       it "update availability status" do
-        expect(Sources::Api::Events).not_to receive(:raise_event)
+        expect(Sources::Api::Events).to receive(:raise_event)
 
         included_attributes = {"availability_status" => "available"}
         patch(instance_path(instance.id), :params => included_attributes.to_json, :headers => headers)

--- a/spec/requests/api/v2.0/endpoints_spec.rb
+++ b/spec/requests/api/v2.0/endpoints_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe("v2.0 - Endpoints") do
       let(:instance) { create(:endpoint, payload.merge(:tenant => tenant)) }
 
       it "update availability status" do
-        expect(Sources::Api::Events).not_to receive(:raise_event)
+        expect(Sources::Api::Events).to receive(:raise_event)
 
         included_attributes = {"availability_status" => "available"}
         patch(instance_path(instance.id), :params => included_attributes.to_json, :headers => headers)


### PR DESCRIPTION
Subscription Watch needs the `Application.update` messages regarding availability status. We should have validated that no one else needed them before turning them off. 

cc @syncrou 