### PR TITLE
Add support for subwatch + azure

### DIFF
--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -30,6 +30,7 @@
   :dependent_applications: []
   :supported_source_types:
   - amazon
+  - azure
   :supported_authentication_types:
     amazon:
     - cloud-meter-arn


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-12822

There is one issue with this combination: this combo **does not require storing any values** so I didn't create an auth type for this, instead of that I updated the UI to handle AppType+SourceType without any auth type by mocking an "empty" auth type. The UI basically injects empty auth type for this combo.

The other way is to create the empty auth type here, in source_types seed, but as I said it would be empty and it woudln't be used anywhere... and I would have to update the UI to handle empty auth types. So I think the first option is better

Let me know what you think, thanks.