### PR TITLE
Remove defaults from initializers since they're handled in lib class

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,14 +4,14 @@ redis_password = Sources::Api::ClowderConfig.instance["inMemoryDbPassword"]
 
 Sidekiq.configure_server do |config|
   config.redis = {
-    :url      => "redis://#{redis_host || "localhost"}:#{redis_port || 6379}/0",
+    :url      => "redis://#{redis_host}:#{redis_port}/0",
     :password => redis_password
   }
 end
 
 Sidekiq.configure_client do |config|
   config.redis = {
-    :url      => "redis://#{redis_host || "localhost"}:#{redis_port || 6379}/0",
+    :url      => "redis://#{redis_host}:#{redis_port}/0",
     :password => redis_password
   }
 end

--- a/lib/sources/api/clowder_config.rb
+++ b/lib/sources/api/clowder_config.rb
@@ -19,7 +19,7 @@ module Sources
             options["kafkaHost"]   = broker.hostname
             options["kafkaPort"]   = broker.port
             options["inMemoryDbHostname"] = config.inMemoryDb.hostname
-            options["inMemoryDbPort"] = config.inMemoryDb.port
+            options["inMemoryDbPort"]     = config.inMemoryDb.port
             options["inMemoryDbPassword"] = config.inMemoryDb.password
 
             # requested and real topic names can be somewhere(?) different
@@ -39,9 +39,9 @@ module Sources
             options["awsSecretAccessKey"] = ENV['CW_AWS_SECRET_ACCESS_KEY']
             options["kafkaHost"]          = ENV['QUEUE_HOST'] || "localhost"
             options["kafkaPort"]          = (ENV['QUEUE_PORT'] || "9092").to_i
-            options["inMemoryDbHostname"] = ENV['REDIS_HOST'] || "localhost"
-            options["inMemoryDbPort"]     = ENV['REDIS_PORT'] || 6379
-            options["inMemoryDbPassword"] = ENV['REDIS_PASSWORD'] || ""
+            options["inMemoryDbHostname"] = ENV['REDIS_CACHE_HOST'] || "localhost"
+            options["inMemoryDbPort"]     = ENV['REDIS_CACHE_PORT'] || 6379
+            options["inMemoryDbPassword"] = ENV['REDIS_CACHE_PASSWORD'] || ""
             options["kafkaTopics"]        = {}
             options["logGroup"]           = "platform-dev"
             options["metricsPort"]        = (ENV['METRICS_PORT'] || 9394).to_i


### PR DESCRIPTION
forgot to remove these defaults here - causing a crashloop in CI. 

related: https://github.com/RedHatInsights/e2e-deploy/pull/2963