### PR TITLE
Application's availability check callback

### DIFF
--- a/app/models/concerns/availability_status_concern.rb
+++ b/app/models/concerns/availability_status_concern.rb
@@ -35,16 +35,16 @@ module AvailabilityStatusConcern
     save!
   end
 
-  # sets availability status from caller's status
+  # sets availability status from dependent's status
   # now Application -> Source
   #
-  # @param caller [ActiveRecord::Base]
-  def set_availability!(caller)
-    self.availability_status = caller.availability_status
-    if respond_to?(:availability_status_error) && caller.respond_to?(:availability_status_error)
-      self.availability_status_error = caller.availability_status_error
+  # @param dependent [ActiveRecord::Base]
+  def set_availability!(dependent)
+    self.availability_status = dependent.availability_status
+    if respond_to?(:availability_status_error) && dependent.respond_to?(:availability_status_error)
+      self.availability_status_error = dependent.availability_status_error
     end
-    self.last_checked_at = caller.last_checked_at
+    self.last_checked_at = dependent.last_checked_at
     save!
   end
 end

--- a/app/models/concerns/availability_status_concern.rb
+++ b/app/models/concerns/availability_status_concern.rb
@@ -34,4 +34,17 @@ module AvailabilityStatusConcern
     reset_availability
     save!
   end
+
+  # sets availability status from caller's status
+  # now Application -> Source
+  #
+  # @param caller [ActiveRecord::Base]
+  def set_availability!(caller)
+    self.availability_status = caller.availability_status
+    if respond_to?(:availability_status_error) && caller.respond_to?(:availability_status_error)
+      self.availability_status_error = caller.availability_status_error
+    end
+    self.last_checked_at = caller.last_checked_at
+    save!
+  end
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -37,18 +37,23 @@ class Source < ApplicationRecord
     authentications.detect { |a| a.authtype == source_type.superkey_authtype }
   end
 
-  # resets availability status and runs new availability check
-  def reset_availability
-    super
+  # reset from Application can't invoke new check in Application
+  def reset_availability!(availability_check: true)
+    reset_availability(:availability_check => availability_check)
+  end
 
-    availability_check
+  # resets availability status and runs new availability check
+  def reset_availability(availability_check: true)
+    super()
+
+    self.availability_check if availability_check
   end
 
   # requests availability check:
-  # 1) through kafka
+  # 1) through kafka (only for full(endpoint based) check)
   # 2) in connected applications
   def availability_check
-    sources_availability_check
+    sources_availability_check if endpoints.any?
 
     applications.includes(:application_type)
                 .each(&:availability_check)

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -40,7 +40,8 @@ describe Authentication do
             end
 
             it "resets availability status for related application and source" do
-              expect(record.source).to receive(:availability_check).once
+              expect(record.source).not_to receive(:availability_check)
+              expect(record.resource).to receive(:availability_check)
 
               record.update!(update)
 

--- a/spec/requests/api/v1.0/sources_spec.rb
+++ b/spec/requests/api/v1.0/sources_spec.rb
@@ -389,6 +389,7 @@ RSpec.describe("v1.0 - Sources") do
         source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => openshift_topic,
@@ -412,6 +413,7 @@ RSpec.describe("v1.0 - Sources") do
         source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => amazon_topic,
@@ -467,15 +469,7 @@ RSpec.describe("v1.0 - Sources") do
 
         source.applications = [app1, app2]
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => openshift_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(messaging_client).not_to receive(:publish_topic)
 
         request_body = { :source_id => source.id.to_s }.to_json
 

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -369,6 +369,7 @@ RSpec.describe("v2.0 - Sources") do
         source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => openshift_topic,
@@ -392,6 +393,7 @@ RSpec.describe("v2.0 - Sources") do
         source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => amazon_topic,
@@ -447,15 +449,7 @@ RSpec.describe("v2.0 - Sources") do
 
         source.applications = [app1, app2]
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => openshift_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(messaging_client).not_to receive(:publish_topic)
 
         request_body = { :source_id => source.id.to_s }.to_json
 

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -427,6 +427,7 @@ RSpec.describe("v3.0 - Sources") do
         source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => openshift_topic,
@@ -450,6 +451,7 @@ RSpec.describe("v3.0 - Sources") do
         source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = { "name" => "my_source", "source_type_id" => source_type.id.to_s }
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => amazon_topic,
@@ -505,15 +507,7 @@ RSpec.describe("v3.0 - Sources") do
 
         source.applications = [app1, app2]
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => openshift_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(messaging_client).not_to receive(:publish_topic)
 
         request_body = { :source_id => source.id.to_s }.to_json
 

--- a/spec/requests/api/v3.1/sources_spec.rb
+++ b/spec/requests/api/v3.1/sources_spec.rb
@@ -424,10 +424,11 @@ RSpec.describe("v3.1 - Sources") do
         )
       end
 
-      it "success: with valid openshift source" do
+      it "success: with valid openshift source and endpoint" do
         source_type = create(:source_type, :name => "openshift", :vendor => "RedHat", :product_name => "OpenShift")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => openshift_topic,
@@ -451,6 +452,7 @@ RSpec.describe("v3.1 - Sources") do
         source_type = create(:source_type, :name => "amazon", :vendor => "Amazon", :product_name => "Amazon Web Services")
         attributes  = {"name" => "my_source", "source_type_id" => source_type.id.to_s}
         source      = create(:source, attributes.merge("tenant" => tenant))
+        _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
         expect(messaging_client).to receive(:publish_topic)
           .with(hash_including(:service => amazon_topic,
@@ -506,15 +508,7 @@ RSpec.describe("v3.1 - Sources") do
 
         source.applications = [app1, app2]
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => openshift_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(messaging_client).not_to receive(:publish_topic)
 
         request_body = {:source_id => source.id.to_s}.to_json
 


### PR DESCRIPTION
This PR removes sending of availability check requests to kafka -> operation workers if the Source doesn't have an endpoint.

---

- [x] **depends on** https://github.com/RedHatInsights/e2e-deploy/pull/2956
- [x] **depends on** https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/17892

[RHCLOUD-12898](https://issues.redhat.com/browse/RHCLOUD-12898)