### PR TITLE
Add Pause support for Applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # Parser for Clowder config in ENV['ACG_CONFIG'] path
 gem 'cloudwatchlogger',     '~> 0.2.1'
 gem 'clowder-common-ruby',  '~> 0.2.2'
+gem 'discard',              '~> 1.2'
 gem 'insights-api-common',  '~> 5.0', '>= 5.0.2'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'

--- a/app/controllers/api/v3x1.rb
+++ b/app/controllers/api/v3x1.rb
@@ -6,7 +6,6 @@ module Api
       end
     end
 
-    class ApplicationsController     < Api::V3x0::ApplicationsController; end
     class ApplicationTypesController < Api::V3x0::ApplicationTypesController; end
     class ApplicationAuthenticationsController < Api::V3x0::ApplicationAuthenticationsController; end
     class AuthenticationsController  < Api::V3x0::AuthenticationsController; end

--- a/app/controllers/api/v3x1/applications_controller.rb
+++ b/app/controllers/api/v3x1/applications_controller.rb
@@ -2,15 +2,17 @@ module Api
   module V3x1
     class ApplicationsController < Api::V3x0::ApplicationsController
       def pause
-        app = Application.find(params.require(:id)).tap { |s| authorize(s) }
+        app = Application.find(params.require(:application_id)).tap { |s| authorize(s) }
         app.discard!
+        AvailabilityMessageJob.perform_later("Application.pause", app, headers.to_h)
 
         head 204
       end
 
       def unpause
-        app = Application.find(params.require(:id)).tap { |s| authorize(s) }
+        app = Application.find(params.require(:application_id)).tap { |s| authorize(s) }
         app.undiscard!
+        AvailabilityMessageJob.perform_later("Application.unpause", app, headers.to_h)
 
         head 202
       end

--- a/app/controllers/api/v3x1/applications_controller.rb
+++ b/app/controllers/api/v3x1/applications_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V3x1
+    class ApplicationsController < Api::V3x0::ApplicationsController
+      def pause
+        app = Application.find(params.require(:id)).tap { |s| authorize(s) }
+        app.discard!
+
+        head 204
+      end
+
+      def unpause
+        app = Application.find(params.require(:id)).tap { |s| authorize(s) }
+        app.undiscard!
+
+        head 202
+      end
+    end
+  end
+end

--- a/app/jobs/availability_message_job.rb
+++ b/app/jobs/availability_message_job.rb
@@ -1,0 +1,9 @@
+class AvailabilityMessageJob < ApplicationJob
+  queue_as :availability
+
+  def perform(operation, instance, headers)
+    Sidekiq.logger.info("Posting #{operation} to event-stream")
+
+    Sources::Api::Events.raise_event(operation, instance.as_json, headers)
+  end
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -120,12 +120,14 @@ class Application < ApplicationRecord
   # have been paused
   def discard_workflow
     authentications.discard_all
+    application_authentications.discard_all
     source.discard if Application.where(:source_id => source_id).all?(&:discarded?)
   end
 
   # inverse of above.
   def undiscard_workflow
     authentications.undiscard_all
+    application_authentications.undiscard_all
     source.undiscard
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -19,6 +19,9 @@ class Application < ApplicationRecord
   after_create :create_superkey_workflow
   after_destroy :teardown_superkey_workflow
 
+  after_discard :discard_workflow
+  after_undiscard :undiscard_workflow
+
   def reset_availability
     super
 
@@ -111,5 +114,18 @@ class Application < ApplicationRecord
       # pull out the superkey metadata we pass in from the worker
       self.superkey_data = extra.delete("_superkey")
     end
+  end
+
+  # pause all applications and pause source if all applications
+  # have been paused
+  def discard_workflow
+    authentications.discard_all
+    source.discard if Application.where(:source_id => source_id).all?(&:discarded?)
+  end
+
+  # inverse of above.
+  def undiscard_workflow
+    authentications.undiscard_all
+    source.undiscard
   end
 end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,4 +1,5 @@
 class Application < ApplicationRecord
+  include Pausable
   include TenancyConcern
   include EventConcern
   include AvailabilityStatusConcern

--- a/app/models/application_authentication.rb
+++ b/app/models/application_authentication.rb
@@ -1,4 +1,5 @@
 class ApplicationAuthentication < ApplicationRecord
+  include Pausable
   include TenancyConcern
   include EventConcern
   belongs_to :application

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,4 +1,5 @@
 class Authentication < ApplicationRecord
+  include Pausable
   include PasswordConcern
   include TenancyConcern
   include EventConcern

--- a/app/models/concerns/availability_status_concern.rb
+++ b/app/models/concerns/availability_status_concern.rb
@@ -13,6 +13,7 @@ module AvailabilityStatusConcern
     name
     superkey_data
     updated_at
+    paused_at
   ].freeze
 
   # reset availability status only if allowed attributes were changed

--- a/app/models/concerns/pausable.rb
+++ b/app/models/concerns/pausable.rb
@@ -1,0 +1,9 @@
+module Pausable
+  extend ActiveSupport::Concern
+
+  included do
+    include Discard::Model
+
+    self.discard_column = :paused_at
+  end
+end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,6 +1,7 @@
 class Source < ApplicationRecord
   SUPERKEY_WORKFLOW = "account_authorization".freeze
 
+  include Pausable
   include TenancyConcern
   include EventConcern
   include AvailabilityStatusConcern

--- a/app/policies/mixins/write_policy_mixin.rb
+++ b/app/policies/mixins/write_policy_mixin.rb
@@ -4,4 +4,6 @@ module WritePolicyMixin
   end
   alias update? create?
   alias destroy? create?
+  alias pause? create?
+  alias unpause? create?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
       end
       resources :applications,                :only => [:create, :destroy, :index, :show, :update] do
         resources :authentications, :only => [:index]
+        post "pause", :to => "applications#pause"
+        post "unpause", :to => "applications#unpause"
       end
       resources :application_authentications, :only => [:create, :destroy, :index, :show, :update]
       resources :authentications,             :only => [:create, :destroy, :index, :show, :update]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,9 @@
+# This file defines the queues sidekiq will listen on
+# it also defines a weight at which polling occurs.
+#
+# the default queue is a higher priority than the availability
+# queue here for example, because availability operations are low
+# priority.
+:queues:
+  - ["default", 2]
+  - ["availability", 1]

--- a/db/migrate/20210415153443_add_paused_at_columns.rb
+++ b/db/migrate/20210415153443_add_paused_at_columns.rb
@@ -8,5 +8,8 @@ class AddPausedAtColumns < ActiveRecord::Migration[5.2]
 
     add_column :authentications, :paused_at, :datetime
     add_index :authentications, :paused_at
+
+    add_column :application_authentications, :paused_at, :datetime
+    add_index :application_authentications, :paused_at
   end
 end

--- a/db/migrate/20210415153443_add_paused_at_columns.rb
+++ b/db/migrate/20210415153443_add_paused_at_columns.rb
@@ -1,0 +1,12 @@
+class AddPausedAtColumns < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sources, :paused_at, :datetime
+    add_index :sources, :paused_at
+
+    add_column :applications, :paused_at, :datetime
+    add_index :applications, :paused_at
+
+    add_column :authentications, :paused_at, :datetime
+    add_index :authentications, :paused_at
+  end
+end

--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -541,6 +541,60 @@
         }
       }
     },
+    "/applications/{id}/pause": {
+      "post": {
+        "summary": "Pauses an Application",
+        "operationId": "pauseApplication",
+        "description": "Pauses an Application",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Application Paused"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/applications/{id}/unpause": {
+      "post": {
+        "summary": "Un-Pauses an Application",
+        "operationId": "unpauseApplication",
+        "description": "Un-Pauses an Application",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ID"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Application Un-Paused"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/authentications": {
       "get": {
         "summary": "List Authentications",

--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -555,6 +555,9 @@
           "204": {
             "description": "Application Paused"
           },
+          "400": {
+            "description": "Bad request"
+          },
           "404": {
             "description": "Not found",
             "content": {
@@ -581,6 +584,9 @@
         "responses": {
           "202": {
             "description": "Application Un-Paused"
+          },
+          "400": {
+            "description": "Bad request"
           },
           "404": {
             "description": "Not found",
@@ -1715,6 +1721,11 @@
             "format": "date-time",
             "readOnly": true,
             "type": "string"
+          },
+          "paused_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -1933,6 +1944,11 @@
           },
           "username": {
             "example": "user@example.com",
+            "type": "string"
+          },
+          "paused_at": {
+            "format": "date-time",
+            "readOnly": true,
             "type": "string"
           }
         },
@@ -2202,6 +2218,11 @@
             "example": "6.5.0",
             "readOnly": true,
             "title": "Version",
+            "type": "string"
+          },
+          "paused_at": {
+            "format": "date-time",
+            "readOnly": true,
             "type": "string"
           }
         },

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -119,4 +119,29 @@ RSpec.describe("Application") do
       end
     end
   end
+
+  describe "pausing" do
+    let!(:source) { create(:source) }
+    let!(:app1) { Application.create!(:source => source, :tenant => source.tenant, :application_type => create(:application_type)) }
+    let!(:app2) { Application.create!(:source => source, :tenant => source.tenant, :application_type => app1.application_type) }
+    let!(:auth) { Authentication.create!(:resource => app1, :tenant => source.tenant) }
+
+    before do
+      # TODO: i have no idea why this is necessary. it doesn't make sense
+      app1.authentications << auth
+    end
+
+    it "discards dependent authentications" do
+      app1.discard
+
+      expect(auth.reload.discarded?).to be_truthy
+    end
+
+    it "discards the source when all applications are discarded" do
+      app1.discard
+      app2.discard
+
+      expect(app1.reload.source.discarded?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-9850

EDIT: 4/20/21 - this is ready to go. there is one really odd thing going on with the specs - its something to do with how AR relations form - it won't work unless I manually assign the auth to the application for the first spec. If there is a way to get around that I'm all ears!

This PR:
- [x] adds the `discard` gem
- [x] adds a `Pausable` concern which includes the module + sets the column to `paused_at`
- [x] adds `POST /applications/:id/pause` and `POST /applications/:id/unpause` endpoints for handling the pausing
- [x] updates the OpenAPI schema with the changes. 
- [x] adds before/after_discard callbacks to handle source discard status
- [x] discards dependent authentications
- [x] posts pause/unpause events via a job
- [x] specs