### PR TITLE
Add check for superkey-worker completion before sending destroy_application request to worker

### DIFF
--- a/lib/sources/super_key.rb
+++ b/lib/sources/super_key.rb
@@ -36,6 +36,8 @@ module Sources
     end
 
     def teardown
+      return unless @application.superkey_data
+
       Sources::Api::Messaging.send_superkey_destroy_request(
         :application => @application
       )


### PR DESCRIPTION
This fixes the bug being seen on CI/Stage related to failing to delete a source. 

This is caused by the `superkey_data` field being empty on the Application, which leads to a nomethoderror when attempting to send the destroy_application request to the worker. 

It only seems to happen when the the user would create/delete a source in quick succession. Either that or when the superkey worker never posted back (which is odd - that should not be happening even on error). 

Either way, I was able to reproduce and this fixes it. 
