### PR TITLE
[WIP] [HABERDASHER] Use insights-logger-ruby gem through insights-api-common

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,12 @@ COPY docker-assets/run_sidekiq /usr/bin
 COPY docker-assets/seed_database /usr/bin
 
 RUN chgrp -R 0 $WORKDIR && \
-    chmod -R g=u $WORKDIR
-
+    chmod -R g=u $WORKDIR && \
+    curl -L -o /usr/bin/haberdasher \
+    https://github.com/RedHatInsights/haberdasher/releases/latest/download/haberdasher_linux_amd64 && \
+    chmod 755 /usr/bin/haberdasher
 # for compatibility with CI
 EXPOSE 3000 8000
 
-ENTRYPOINT ["entrypoint"]
-CMD ["run_rails_server"]
+ENTRYPOINT ["/usr/bin/haberdasher"]
+CMD ["entrypoint", "run_rails_server"]

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,11 @@ plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 # Parser for Clowder config in ENV['ACG_CONFIG'] path
-gem 'cloudwatchlogger',     '~> 0.2.1'
 gem 'clowder-common-ruby',  '~> 0.2.2'
 gem 'discard',              '~> 1.2'
-gem 'insights-api-common',  '~> 5.0', '>= 5.0.2'
+gem 'insights-api-common',  '~> 5.0', '>= 5.0.3'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
-gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"
 gem 'manageiq-messaging',   '~> 1.0.0'
 gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"
 gem 'more_core_extensions', '~> 3.5'

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module Sources
     config.active_job.queue_adapter = :sidekiq
 
     config.log_level = (ENV['RAILS_LOG_LEVEL'] || 'debug').downcase.to_sym
-    Insights::API::Common::Logging.activate(config)
+    Insights::API::Common::Logging.activate(config, "sources-api")
 
     # ManageIQ Metrics depends on these variables
     require "sources/api/clowder_config"


### PR DESCRIPTION
NOTE: I expect that next version of insights-api-common will be 5.0.3. But now it doesn't exists yet.

https://issues.redhat.com/browse/RHCLOUD-13753

REQUIRED:
- [x] https://github.com/RedHatInsights/insights-api-common-rails/pull/225