### PR TITLE
Only start availability_status_listener in the main sources-api pod

### DIFF
--- a/config/initializers/availability_status_listener.rb
+++ b/config/initializers/availability_status_listener.rb
@@ -2,7 +2,10 @@ require 'sources/api/clowder_config'
 
 # Be sure to restart your server when you modify this file.
 
-unless defined?(::Rails::Console)
+# we ony want the AvailabilityStatusListener to start for the api pod, NOT the sidekiq pod.
+sidekiq_pod = Rails.env.production? && ENV['HOSTNAME'].match?(/sidekiq/)
+
+unless defined?(::Rails::Console) || sidekiq_pod
   queue_host = Sources::Api::ClowderConfig.instance['kafkaHost']
   queue_port = Sources::Api::ClowderConfig.instance['kafkaPort']
 


### PR DESCRIPTION
Found this while making sure the sidekiq worker was working - basically sidekiq initializes the entire rials app when it starts up, and we do _not_ want multiple listeners running since that could get confusing if we need to debug it ever. 

This PR adds a constraint to the listener so it only runs the pod in non-sidekiq hostname situations. I tried to think of another way, but didn't really want to add another ENV var to say "run listener" and the like. 

Open to suggestions if there are any since I know this isn't entirely clean. 