### PR TITLE
Internal SourcesController

### DIFF
--- a/app/controllers/internal/v2x0/mixins/index_mixin.rb
+++ b/app/controllers/internal/v2x0/mixins/index_mixin.rb
@@ -1,0 +1,37 @@
+module Internal
+  module V2x0
+    module Mixins
+      module IndexMixin
+        def index
+          raise_unless_primary_instance_exists
+
+          # Tenancy not wanted
+          ActsAsTenant.without_tenant do
+            render :json => Insights::API::Common::PaginatedResponse.new(
+              :base_query => scoped(filtered.where(params_for_list)),
+              :request    => request,
+              :limit      => pagination_limit,
+              :offset     => pagination_offset,
+              :sort_by    => query_sort_by
+            ).response
+          end
+        end
+
+        def scoped(relation)
+          if through_relation_klass
+            relation = relation.joins(through_relation_name)
+          end
+
+          relation
+        end
+
+        def raise_unless_primary_instance_exists
+          return unless subcollection?
+
+          klass = request_path_parts["primary_collection_name"].singularize.camelize.safe_constantize
+          klass.find(request_path_parts["primary_collection_id"].to_i)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/internal/v2x0/mixins/open_api_mixin.rb
+++ b/app/controllers/internal/v2x0/mixins/open_api_mixin.rb
@@ -1,0 +1,14 @@
+module Internal
+  module V2x0
+    module Mixins
+      module OpenApiMixin
+        extend ActiveSupport::Concern
+        module ClassMethods
+          def api_doc
+            @api_doc ||= ::Sources::Api::InternalDocs.instance['2.0']
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/internal/v2x0/sources_controller.rb
+++ b/app/controllers/internal/v2x0/sources_controller.rb
@@ -1,11 +1,8 @@
-require "sources/api/internal_docs"
-
 module Internal
   module V2x0
-    class TenantsController < ::ApplicationController
+    class SourcesController < ::ApplicationController
       include ::Internal::V2x0::Mixins::OpenApiMixin
       include ::Internal::V2x0::Mixins::IndexMixin
-      include ::Api::V1::Mixins::ShowMixin
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,6 +139,7 @@ Rails.application.routes.draw do
 
     namespace :v2x0, :path => "v2.0" do
       resources :authentications, :only => [:show]
+      resources :sources,         :only => [:index]
       resources :tenants,         :only => [:index, :show]
     end
   end

--- a/private/doc/openapi-3-v2.0.json
+++ b/private/doc/openapi-3-v2.0.json
@@ -54,6 +54,39 @@
         }
       }
     },
+    "/sources": {
+      "get": {
+        "summary": "List Sources",
+        "operationId": "listSources",
+        "description": "Returns an array of Source objects",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/QueryLimit"
+          },
+          {
+            "$ref": "#/components/parameters/QueryOffset"
+          },
+          {
+            "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tenants collection",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantsCollection"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/tenants": {
       "get": {
         "summary": "List Tenants",
@@ -341,6 +374,73 @@
         "description": "Attribute with optional order to sort the result set by.",
         "pattern": "^[a-z\\-_]+(:asc|:desc)?$"
       },
+      "Source": {
+        "type": "object",
+        "properties": {
+          "app_creation_workflow": {
+            "type": "string",
+            "enum": [
+              "manual_configuration",
+              "account_authorization"
+            ]
+          },
+          "availability_status": {
+            "type": "string"
+          },
+          "created_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "imported": {
+            "type": "string"
+          },
+          "last_available_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "last_checked_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "name": {
+            "example": "Sample Provider",
+            "title": "Name",
+            "type": "string"
+          },
+          "source_ref": {
+            "type": "string"
+          },
+          "source_type_id": {
+            "$ref": "#/components/schemas/ID"
+          },
+          "uid": {
+            "readOnly": true,
+            "title": "Unique ID of the inventory source installation",
+            "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "version": {
+            "example": "6.5.0",
+            "readOnly": true,
+            "title": "Version",
+            "type": "string"
+          },
+          "paused_at": {
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      },
       "Tenant": {
         "type": "object",
         "properties": {
@@ -368,6 +468,23 @@
           }
         },
         "additionalProperties": false
+      },
+      "SourcesCollection": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/CollectionMetadata"
+          },
+          "links": {
+            "$ref": "#/components/schemas/CollectionLinks"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Source"
+            }
+          }
+        }
       },
       "TenantsCollection": {
         "type": "object",

--- a/private/doc/openapi-3-v2.0.json
+++ b/private/doc/openapi-3-v2.0.json
@@ -75,11 +75,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Tenants collection",
+            "description": "Sources collection",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TenantsCollection"
+                  "$ref": "#/components/schemas/SourcesCollection"
                 }
               }
             }

--- a/spec/controllers/internal/v2x0/index_mixin_spec.rb
+++ b/spec/controllers/internal/v2x0/index_mixin_spec.rb
@@ -1,0 +1,38 @@
+describe Internal::V2x0::Mixins::IndexMixin do
+  describe Internal::V2x0::SourcesController, :type => :request do
+    include ::Spec::Support::TenantIdentity
+
+    let(:headers)      { {"CONTENT_TYPE" => "application/json", "x-rh-identity" => identity} }
+    let!(:tenant2)           { Tenant.create!(:name => "2nd tenant", :external_tenant => external_tenant2) }
+    let!(:external_tenant2)  { rand(1000).to_s }
+
+    let!(:source_1)    { create(:source, :name => "source 1 tenant 1", :tenant => tenant) }
+    let!(:source_2)    { create(:source, :name => "source 2 tenant 1", :tenant => tenant) }
+    let!(:source_3)    { create(:source, :name => "source 3 tenant 2", :tenant => tenant2) }
+
+    it "Primary Collection: get /sources lists all Sources" do
+      get(internal_v2x0_sources_url, :headers => headers)
+
+      expect(response.status).to eq(200)
+      expect(response.parsed_body["data"]).to match([a_hash_including("id" => source_1.id.to_s),
+                                                     a_hash_including("id" => source_2.id.to_s),
+                                                     a_hash_including("id" => source_3.id.to_s)])
+    end
+
+    context "paging" do
+      it "response_structure" do
+        get(internal_v2x0_sources_url, :headers => headers)
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body.keys).to eq(["meta", "links", "data"])
+      end
+
+      it "meta/count" do
+        get(internal_v2x0_sources_url, :headers => headers)
+
+        expect(response.status).to eq(200)
+        expect(response.parsed_body["meta"]).to eq("count" => 3, "limit" => 100, "offset" => 0)
+      end
+    end
+  end
+end

--- a/spec/swagger_spec.rb
+++ b/spec/swagger_spec.rb
@@ -41,6 +41,7 @@ describe "Swagger stuff" do
           {:path => "/internal/v2.0/tenants",             :verb => "GET"},
           {:path => "/internal/v2.0/tenants/:id",         :verb => "GET"},
           {:path => "/internal/v2.0/authentications/:id", :verb => "GET"},
+          {:path => "/internal/v2.0/sources",             :verb => "GET"}
         ]
         health_check_routes = [
           {:path => "/health", :verb => "GET"}


### PR DESCRIPTION
Primary usage of the internal/v2.0/sources is by SourcesMonitor cronjobs to avoid tenant based multiple queries.

Btw (not related to this PR) I found either insights-api-common or acts-as-tenant are introducing N+1 queries problem when requesting Source.all (in both this and public SourcesController)

- [x] **depends on** #390 

---

[RHCLOUD-14101](https://issues.redhat.com/browse/RHCLOUD-14101)