### PR TITLE
Remove redundant tenant relation

### DIFF
--- a/app/models/concerns/tenancy_concern.rb
+++ b/app/models/concerns/tenancy_concern.rb
@@ -2,7 +2,6 @@ module TenancyConcern
   extend ActiveSupport::Concern
 
   included do
-    belongs_to :tenant
     acts_as_tenant :tenant
   end
 


### PR DESCRIPTION
Regarding https://github.com/ErwinM/acts_as_tenant#belongs_to-options
the `belongs_to` was duplicated