### PR TITLE
fix bulk_message to handle when an authentication is attached to a source

### DIFF
--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -15,12 +15,13 @@ module EventConcern
                     :application_authentications => ApplicationAuthentication.where(:authentication => authentications)
                   }
                 when "Authentication"
+                  source = resource.try(:source) || resource
                   {
-                    :source                      => resource.source,
-                    :applications                => resource.source.applications,
-                    :endpoints                   => resource.source.endpoints,
-                    :authentications             => resource.authentications,
-                    :application_authentications => ApplicationAuthentication.where(:authentication => resource.authentications)
+                    :source                      => source,
+                    :applications                => source.applications,
+                    :endpoints                   => source.endpoints,
+                    :authentications             => source.authentications,
+                    :application_authentications => ApplicationAuthentication.where(:authentication => source.authentications)
                   }
                 when "ApplicationAuthentication"
                   {


### PR DESCRIPTION
Fixes the error in the response when using bulk-create to create a superkey source - the bulk message functionality errored out on the message produce even though the objects were still created. 