### PR TITLE
Add Sidekiq job for availability message processing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,5 +32,6 @@ end
 group :test do
   gem "factory_bot_rails"
   gem 'rspec-rails', '~>3.8'
+  gem 'timecop'
   gem 'webmock'
 end

--- a/app/jobs/availability_status_update_job.rb
+++ b/app/jobs/availability_status_update_job.rb
@@ -1,0 +1,38 @@
+class AvailabilityStatusUpdateJob < ApplicationJob
+  queue_as :availability
+
+  def perform(event, headers)
+    payload = JSON.parse(event)
+    model_class = payload["resource_type"].classify.constantize
+
+    validate_resource_type(model_class)
+
+    record_id = payload["resource_id"]
+    object = model_class.find(record_id)
+
+    options = {
+      :availability_status => payload["status"],
+      :last_checked_at     => Time.now.utc
+    }
+
+    options[:availability_status_error] = payload["error"] if %(Endpoint Application).include?(model_class.name)
+    options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
+
+    object.update!(options)
+
+    object.raise_event_for_update(options.keys, headers)
+  rescue NameError
+    Sidekiq.logger.error("Invalid resource_type #{payload["resource_type"]}")
+  rescue ActiveRecord::RecordNotFound
+    Sidekiq.logger.error("Could not find #{model_class} with id #{record_id}")
+  rescue ActiveRecord::RecordInvalid
+    Sidekiq.logger.error("Invalid status #{payload["status"]}")
+  rescue => e
+    Sidekiq.logger.error(["Something is wrong when processing Kafka message: ", e.message, *e.backtrace].join($RS))
+  end
+
+  def validate_resource_type(model_class)
+    # For security reason only accept explicitly listed models
+    raise NameError unless [Application, Endpoint, Source].include?(model_class)
+  end
+end

--- a/app/jobs/availability_status_update_job.rb
+++ b/app/jobs/availability_status_update_job.rb
@@ -15,7 +15,7 @@ class AvailabilityStatusUpdateJob < ApplicationJob
       :last_checked_at     => Time.now.utc
     }
 
-    options[:availability_status_error] = payload["error"] if %(Endpoint Application).include?(model_class.name)
+    options[:availability_status_error] = payload["error"] if %(Endpoint Application Authentication).include?(model_class.name)
     options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
 
     object.update!(options)
@@ -33,6 +33,6 @@ class AvailabilityStatusUpdateJob < ApplicationJob
 
   def validate_resource_type(model_class)
     # For security reason only accept explicitly listed models
-    raise NameError unless [Application, Endpoint, Source].include?(model_class)
+    raise NameError unless [Application, Authentication, Endpoint, Source].include?(model_class)
   end
 end

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -29,7 +29,7 @@ objects:
         - name: APP_NAME
           value: ${APP_NAME}
         - name: DB_POOL_SIZE
-          value: ${DB_POOL_SIZE}
+          value: ${SIDEKIQ_DB_POOL_SIZE}
         - name: RAILS_LOG_LEVEL
           value: ${LOG_LEVEL}
           # TODO: It never can be blank!
@@ -184,6 +184,10 @@ parameters:
   displayName: Database Pool size
   description: Database pool configuration in DATABASE_URL env
   value: "5"
+- name: SIDEKIQ_DB_POOL_SIZE
+  displayName: Database Pool size
+  description: Database pool configuration in sidekiq DATABASE_URL env
+  value: "20"
 - name: ENCRYPTION_KEY
   displayName: Encryption Key (Ephemeral)
   required: true

--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -45,38 +45,8 @@ class AvailabilityStatusListener
       return
     end
 
-    payload = JSON.parse(event.payload)
-    model_class = payload["resource_type"].classify.constantize
-    validate_resource_type(model_class)
-    record_id = payload["resource_id"]
-    object = model_class.find(record_id)
-    options = {
-      :availability_status => payload["status"],
-      :last_checked_at     => Time.now.utc
-    }
-    options[:availability_status_error] = payload["error"] if %(Endpoint Application).include?(model_class.name)
-    options[:last_available_at] = options[:last_checked_at] if options[:availability_status] == 'available'
-
-    object.update!(options)
-    object.raise_event_for_update(options.keys, event.headers)
-  rescue NameError
-    Rails.logger.error("Invalid resource_type #{payload["resource_type"]}")
-  rescue ActiveRecord::RecordNotFound
-    Rails.logger.error("Could not find #{model_class} with id #{record_id}")
-  rescue ActiveRecord::RecordInvalid
-    Rails.logger.error("Invalid status #{payload["status"]}")
-  rescue ActiveRecord::StatementInvalid, PG::UnableToSend
-    Rails.logger.error("Ran into error connecting to db - retrying.")
-    ActiveRecord::Base.establish_connection
-
-    retry
-  rescue => e
-    Rails.logger.error(["Something is wrong when processing Kafka message: ", e.message, *e.backtrace].join($RS))
-  end
-
-  def validate_resource_type(model_class)
-    # For security reason only accept explicitly listed models
-    raise NameError unless [Application, Endpoint, Source].include?(model_class)
+    # async processing so we can process 5 (or more) at once.
+    AvailabilityStatusUpdateJob.perform_later(event.payload, event.headers)
   end
 
   def default_messaging_options

--- a/spec/jobs/availability_status_update_job_spec.rb
+++ b/spec/jobs/availability_status_update_job_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe AvailabilityStatusUpdateJob, :type => :job do
-  let(:now)        { Time.new(2020).utc }
-  let(:payload)    { {"resource_type" => resource_type, "resource_id" => resource_id, "status" => status, "error" => reason}.to_json }
-  let(:headers)    { {"SECRET_HEADER" => "PASSWORD", "x-rh-identity" => "ayyyy"} }
-  let(:reason)     { "host unreachable" }
-  let(:status)     { "unavailable" }
+  let(:now)     { Time.utc(2020, 1, 1, 12, 30) }
+  let(:payload) { {"resource_type" => resource_type, "resource_id" => resource_id, "status" => status, "error" => reason}.to_json }
+  let(:headers) { {"SECRET_HEADER" => "PASSWORD", "x-rh-identity" => "ayyyy"} }
+  let(:reason)  { "host unreachable" }
+  let(:status)  { "unavailable" }
 
   subject { AvailabilityStatusUpdateJob }
 
@@ -16,7 +16,7 @@ RSpec.describe AvailabilityStatusUpdateJob, :type => :job do
     let(:resource_type) { "endpoint" }
     let(:resource_id)   { endpoint.id.to_s }
 
-    before { allow(Time).to receive(:now).and_return(now) }
+    before { Timecop.freeze(now) }
 
     context "when status is available" do
       let(:status) { "available" }

--- a/spec/jobs/availability_status_update_job_spec.rb
+++ b/spec/jobs/availability_status_update_job_spec.rb
@@ -1,0 +1,110 @@
+require 'rails_helper'
+
+RSpec.describe AvailabilityStatusUpdateJob, :type => :job do
+  let(:now)        { Time.new(2020).utc }
+  let(:payload)    { {"resource_type" => resource_type, "resource_id" => resource_id, "status" => status, "error" => reason}.to_json }
+  let(:headers)    { {"SECRET_HEADER" => "PASSWORD", "x-rh-identity" => "ayyyy"} }
+  let(:reason)     { "host unreachable" }
+  let(:status)     { "unavailable" }
+
+  subject { AvailabilityStatusUpdateJob }
+
+  context "when body contains valid resource_type and id" do
+    let(:endpoint) do
+      create(:endpoint, :role => "first", :default => true)
+    end
+    let(:resource_type) { "endpoint" }
+    let(:resource_id)   { endpoint.id.to_s }
+
+    before { allow(Time).to receive(:now).and_return(now) }
+
+    context "when status is available" do
+      let(:status) { "available" }
+
+      context "Source" do
+        it "updates availability status and last_available_at" do
+          expect(Sources::Api::Events).to receive(:raise_event).twice
+
+          subject.perform_now(payload, headers)
+
+          endpoint.reload
+          expect(endpoint).to have_attributes(
+            :availability_status       => status,
+            :availability_status_error => reason,
+            :last_available_at         => now,
+            :last_checked_at           => now
+          )
+        end
+      end
+
+      context "Application" do
+        let(:application) { create(:application) }
+
+        let(:resource_type) { "application" }
+        let(:resource_id)   { application.id.to_s }
+
+        it "updates availability status and last_available_at" do
+          expect(Sources::Api::Events).to receive(:raise_event).twice
+
+          subject.perform_now(payload, headers)
+
+          application.reload
+          expect(application).to have_attributes(
+            :availability_status       => status,
+            :availability_status_error => reason,
+            :last_available_at         => now,
+            :last_checked_at           => now
+          )
+        end
+      end
+    end
+
+    context "when status is unavailable" do
+      it "updates availability status" do
+        expect(Sources::Api::Events).to receive(:raise_event).twice
+
+        subject.perform_now(payload, headers)
+
+        endpoint.reload
+        expect(endpoint).to have_attributes(
+          :availability_status       => status,
+          :availability_status_error => reason,
+          :last_available_at         => nil,
+          :last_checked_at           => now
+        )
+      end
+    end
+
+    context "when status is invalid" do
+      let(:status) { "wrong status" }
+
+      it "logs invalid status" do
+        expect(Sidekiq.logger).to receive(:error).with("Invalid status #{status}")
+
+        subject.perform_now(payload, headers)
+      end
+    end
+  end
+
+  context "when resource_type is invalid" do
+    let(:resource_type) { "something" }
+    let(:resource_id)   { "1" }
+
+    it "logs invalid resource type" do
+      expect(Sidekiq.logger).to receive(:error).with("Invalid resource_type #{resource_type}")
+
+      subject.perform_now(payload, headers)
+    end
+  end
+
+  context "when resource_id does not exist" do
+    let(:resource_type) { "Endpoint" }
+    let(:resource_id)   { "1" }
+
+    it "logs record not exist" do
+      expect(Sidekiq.logger).to receive(:error).with("Could not find #{resource_type} with id #{resource_id}")
+
+      subject.perform_now(payload, headers)
+    end
+  end
+end

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -1,14 +1,12 @@
 RSpec.describe AvailabilityStatusListener do
   let(:client)     { double(:client) }
   let(:event_type) { AvailabilityStatusListener::EVENT_AVAILABILITY_STATUS }
-  let(:payload)    { {"resource_type" => resource_type, "resource_id" => resource_id, "status" => status, "error" => reason}.to_json }
-  let(:status)     { "unavailable" }
-  let(:reason)     { "host unreachable" }
-  let(:now)        { Time.new(2020).utc }
-  let(:headers)    { {"SECRET_HEADER" => "PASSWORD", "x-rh-identity" => "ayyyy"} }
-  let(:message)    { ManageIQ::Messaging::ReceivedMessage.new(nil, event_type, payload, headers, nil, client) }
+  let(:payload)    { {:update => true}.to_json }
+  let(:headers)    { {"SECRET_HEADER" => "PASSWORD", "x-rh-identity" => "ayyy"} }
 
   describe "#subscribe_to_availability_status" do
+    let(:message) { ManageIQ::Messaging::ReceivedMessage.new(nil, event_type, payload, headers, nil, client) }
+
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).with(
         :protocol => :Kafka,
@@ -22,100 +20,19 @@ RSpec.describe AvailabilityStatusListener do
       ).and_yield(message)
     end
 
-    context "when body contains valid resource_type and id" do
-      let(:endpoint) do
-        create(:endpoint, :role => "first", :default => true)
-      end
-      let(:resource_type) { "endpoint" }
-      let(:resource_id)   { endpoint.id.to_s }
-
-      before { allow(Time).to receive(:now).and_return(now) }
-
-      context "when status is available" do
-        let(:status) { "available" }
-
-        context "Source" do
-          it "updates availability status and last_available_at" do
-            expect(Sources::Api::Events).to receive(:raise_event).twice
-
-            subject.subscribe_to_availability_status
-
-            endpoint.reload
-            expect(endpoint).to have_attributes(
-              :availability_status       => status,
-              :availability_status_error => reason,
-              :last_available_at         => now,
-              :last_checked_at           => now
-            )
-          end
-        end
-
-        context "Application" do
-          let(:application) { create(:application) }
-
-          let(:resource_type) { "application" }
-          let(:resource_id)   { application.id.to_s }
-
-          it "updates availability status and last_available_at" do
-            expect(Sources::Api::Events).to receive(:raise_event).twice
-
-            subject.subscribe_to_availability_status
-
-            application.reload
-            expect(application).to have_attributes(
-              :availability_status       => status,
-              :availability_status_error => reason,
-              :last_available_at         => now,
-              :last_checked_at           => now
-            )
-          end
-        end
-      end
-
-      context "when status is unavailable" do
-        it "updates availability status" do
-          expect(Sources::Api::Events).to receive(:raise_event).twice
-
-          subject.subscribe_to_availability_status
-
-          endpoint.reload
-          expect(endpoint).to have_attributes(
-            :availability_status       => status,
-            :availability_status_error => reason,
-            :last_available_at         => nil,
-            :last_checked_at           => now
-          )
-        end
-      end
-
-      context "when status is invalid" do
-        let(:status) { "wrong status" }
-
-        it "logs invalid status" do
-          expect(Rails.logger).to receive(:error).with("Invalid status #{status}")
-
-          subject.subscribe_to_availability_status
-        end
-      end
-    end
-
-    context "when resource_type is invalid" do
-      let(:resource_type) { "something" }
-      let(:resource_id)   { "1" }
-
-      it "logs invalid resource type" do
-        expect(Rails.logger).to receive(:error).with("Invalid resource_type #{resource_type}")
+    context "with the availability_status event_type" do
+      it "enqueues the AvailabilityStatusUpdateJob" do
+        expect(AvailabilityStatusUpdateJob).to receive(:perform_later).with(payload, headers).once
 
         subject.subscribe_to_availability_status
       end
     end
 
-    context "when resource_id does not exist" do
-      let(:resource_type) { "Endpoint" }
-      let(:resource_id)   { "1" }
+    context "with the wrong event_type" do
+      let(:event_type) { "not right" }
 
-      it "logs record not exist" do
-        expect(Rails.logger).to receive(:error).with("Could not find #{resource_type} with id #{resource_id}")
+      it "does not enqueue the AvailabilityStatusUpdateJob" do
+        expect(AvailabilityStatusUpdateJob).not_to receive(:perform_later)
 
         subject.subscribe_to_availability_status
       end


### PR DESCRIPTION
This is part of my hackathon work!

Basically moving the availability status listener's guts into a sidekiq job - so we can process more of them than one at a time. The biggest problem before was that we processed the update messages serially - so it could take quite a while to process if a bunch of them came back at once. This way we can increase the number of sidekiq workers and process them as fast as we want. 

cc @syncrou 