### PR TITLE
Add sidekiq job for requesting endpoint availability

### DIFF
--- a/app/jobs/kafka_publish_job.rb
+++ b/app/jobs/kafka_publish_job.rb
@@ -1,0 +1,13 @@
+class KafkaPublishJob < ApplicationJob
+  queue_as :default
+
+  def perform(topic, event, payload)
+    Sidekiq.logger.info("Publishing #{event} to #{topic}...")
+
+    Sources::Api::Messaging.client.publish_topic(
+      :service => topic,
+      :event   => event,
+      :payload => payload
+    )
+  end
+end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -69,18 +69,16 @@ class Source < ApplicationRecord
     begin
       logger.debug("Publishing message for Source#availability_check [#{{"source_id" => id, "topic" => topic}}]")
 
-      Sources::Api::Messaging.client.publish_topic(
-        :service => topic,
-        :event   => "Source.availability_check",
-        :payload => {
-          :params => {
-            :source_id       => id.to_s,
-            :source_uid      => uid.to_s,
-            :source_ref      => source_ref.to_s,
-            :external_tenant => tenant.external_tenant
-          }
+      payload = {
+        :params => {
+          :source_id       => id.to_s,
+          :source_uid      => uid.to_s,
+          :source_ref      => source_ref.to_s,
+          :external_tenant => tenant.external_tenant
         }
-      )
+      }
+
+      KafkaPublishJob.perform_later(topic, "Source.availability_check", payload)
 
       logger.debug("Publishing message for Source#availability_check [#{{"source_id" => id, "topic" => topic}}]...Complete")
     rescue => e

--- a/spec/jobs/kafka_publish_job_spec.rb
+++ b/spec/jobs/kafka_publish_job_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe KafkaPublishJob, :type => :job do
+  let(:client) { instance_double(ManageIQ::Messaging::Client) }
+  before do
+    allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+    allow(client).to receive(:publish_topic)
+  end
+
+  let(:payload) { {:thing => true}.to_json }
+
+  it "publishes the message/event/payload specified" do
+    expect(client).to receive(:publish_topic).with(
+      :service => "some_topic",
+      :event   => "test_event",
+      :payload => payload
+    )
+
+    KafkaPublishJob.perform_now("some_topic", "test_event", payload)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,11 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'spec_helper'
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
+
+# disable sidekiq logging during tests
+require 'sidekiq/testing'
+Sidekiq::Logging.logger = nil
+
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/api/v2.0/sources_spec.rb
+++ b/spec/requests/api/v2.0/sources_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe("v2.0 - Sources") do
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v2.0/sources" }
   let(:source_type)     { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
-  let(:client)          { instance_double("ManageIQ::Messaging::Client") }
+  let(:client) { instance_double(ManageIQ::Messaging::Client) }
   before do
-    allow(client).to receive(:publish_topic)
     allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+    allow(client).to receive(:publish_topic)
   end
 
   describe("/api/v2.0/sources") do
@@ -342,17 +342,11 @@ RSpec.describe("v2.0 - Sources") do
   end
 
   describe("/api/v2.0/sources/:id/check_availability") do
-    let(:messaging_client)  { double("Sources::Api::Messaging") }
     let(:openshift_topic)   { "platform.topological-inventory.operations-openshift" }
     let(:amazon_topic)      { "platform.topological-inventory.operations-amazon" }
 
     def check_availability_path(source_id)
       File.join(collection_path, source_id.to_s, "check_availability")
-    end
-
-    before do
-      allow(messaging_client).to receive(:publish_topic)
-      allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
     end
 
     context "post" do
@@ -371,15 +365,16 @@ RSpec.describe("v2.0 - Sources") do
         source      = create(:source, attributes.merge("tenant" => tenant))
         _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => openshift_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(KafkaPublishJob).to receive(:perform_later).with(
+          openshift_topic,
+          "Source.availability_check",
+          a_hash_including(
+            :params => a_hash_including(
+              :source_id       => source.id.to_s,
+              :external_tenant => tenant.external_tenant
+            )
+          )
+        )
 
         post(check_availability_path(source.id), :headers => headers)
 
@@ -395,15 +390,16 @@ RSpec.describe("v2.0 - Sources") do
         source      = create(:source, attributes.merge("tenant" => tenant))
         _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => amazon_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(KafkaPublishJob).to receive(:perform_later).with(
+          amazon_topic,
+          "Source.availability_check",
+          a_hash_including(
+            :params => a_hash_including(
+              :source_id       => source.id.to_s,
+              :external_tenant => tenant.external_tenant
+            )
+          )
+        )
 
         post(check_availability_path(source.id), :headers => headers)
 
@@ -449,7 +445,7 @@ RSpec.describe("v2.0 - Sources") do
 
         source.applications = [app1, app2]
 
-        expect(messaging_client).not_to receive(:publish_topic)
+        expect(KafkaPublishJob).not_to receive(:perform_later)
 
         request_body = { :source_id => source.id.to_s }.to_json
 

--- a/spec/requests/api/v3.0/sources_spec.rb
+++ b/spec/requests/api/v3.0/sources_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe("v3.0 - Sources") do
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v3.0/sources" }
   let(:source_type)     { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
-  let(:client)          { instance_double("ManageIQ::Messaging::Client") }
+  let(:client) { instance_double(ManageIQ::Messaging::Client) }
   before do
-    allow(client).to receive(:publish_topic)
     allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+    allow(client).to receive(:publish_topic)
   end
 
   describe("/api/v3.0/sources") do
@@ -400,17 +400,11 @@ RSpec.describe("v3.0 - Sources") do
   end
 
   describe("/api/v3.0/sources/:id/check_availability") do
-    let(:messaging_client)  { double("Sources::Api::Messaging") }
     let(:openshift_topic)   { "platform.topological-inventory.operations-openshift" }
     let(:amazon_topic)      { "platform.topological-inventory.operations-amazon" }
 
     def check_availability_path(source_id)
       File.join(collection_path, source_id.to_s, "check_availability")
-    end
-
-    before do
-      allow(messaging_client).to receive(:publish_topic)
-      allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
     end
 
     context "post" do
@@ -429,15 +423,17 @@ RSpec.describe("v3.0 - Sources") do
         source      = create(:source, attributes.merge("tenant" => tenant))
         _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => openshift_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+
+        expect(KafkaPublishJob).to receive(:perform_later).with(
+          openshift_topic,
+          "Source.availability_check",
+          a_hash_including(
+            :params => a_hash_including(
+              :source_id       => source.id.to_s,
+              :external_tenant => tenant.external_tenant
+            )
+          )
+        )
 
         post(check_availability_path(source.id), :headers => headers)
 
@@ -453,15 +449,16 @@ RSpec.describe("v3.0 - Sources") do
         source      = create(:source, attributes.merge("tenant" => tenant))
         _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => amazon_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(KafkaPublishJob).to receive(:perform_later).with(
+          amazon_topic,
+          "Source.availability_check",
+          a_hash_including(
+            :params => a_hash_including(
+              :source_id       => source.id.to_s,
+              :external_tenant => tenant.external_tenant
+            )
+          )
+        )
 
         post(check_availability_path(source.id), :headers => headers)
 
@@ -507,7 +504,7 @@ RSpec.describe("v3.0 - Sources") do
 
         source.applications = [app1, app2]
 
-        expect(messaging_client).not_to receive(:publish_topic)
+        expect(KafkaPublishJob).not_to receive(:perform_later)
 
         request_body = { :source_id => source.id.to_s }.to_json
 

--- a/spec/requests/api/v3.1/sources_spec.rb
+++ b/spec/requests/api/v3.1/sources_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe("v3.1 - Sources") do
   let(:attributes)      { {"name" => "my source", "source_type_id" => source_type.id.to_s} }
   let(:collection_path) { "/api/v3.1/sources" }
   let(:source_type)     { create(:source_type, :name => "SourceType", :vendor => "Some Vendor", :product_name => "Product Name") }
-  let(:client)          { instance_double("ManageIQ::Messaging::Client") }
+  let(:client) { instance_double(ManageIQ::Messaging::Client) }
   before do
-    allow(client).to receive(:publish_topic)
     allow(Sources::Api::Messaging).to receive(:client).and_return(client)
+    allow(client).to receive(:publish_topic)
   end
 
   describe("/api/v3.1/sources") do
@@ -397,17 +397,11 @@ RSpec.describe("v3.1 - Sources") do
   end
 
   describe("/api/v3.1/sources/:id/check_availability") do
-    let(:messaging_client)  { double("Sources::Api::Messaging") }
     let(:openshift_topic)   { "platform.topological-inventory.operations-openshift" }
     let(:amazon_topic)      { "platform.topological-inventory.operations-amazon" }
 
     def check_availability_path(source_id)
       File.join(collection_path, source_id.to_s, "check_availability")
-    end
-
-    before do
-      allow(messaging_client).to receive(:publish_topic)
-      allow(Sources::Api::Messaging).to receive(:client).and_return(messaging_client)
     end
 
     context "post" do
@@ -426,15 +420,16 @@ RSpec.describe("v3.1 - Sources") do
         source      = create(:source, attributes.merge("tenant" => tenant))
         _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => openshift_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(KafkaPublishJob).to receive(:perform_later).with(
+          openshift_topic,
+          "Source.availability_check",
+          a_hash_including(
+            :params => a_hash_including(
+              :source_id       => source.id.to_s,
+              :external_tenant => tenant.external_tenant
+            )
+          )
+        )
 
         post(check_availability_path(source.id), :headers => headers)
 
@@ -450,15 +445,16 @@ RSpec.describe("v3.1 - Sources") do
         source      = create(:source, attributes.merge("tenant" => tenant))
         _endpoint   = create(:endpoint, :source => source, :tenant => tenant)
 
-        expect(messaging_client).to receive(:publish_topic)
-          .with(hash_including(:service => amazon_topic,
-                               :event   => "Source.availability_check",
-                               :payload => a_hash_including(
-                                 :params => a_hash_including(
-                                   :source_id       => source.id.to_s,
-                                   :external_tenant => tenant.external_tenant
-                                 )
-                               )))
+        expect(KafkaPublishJob).to receive(:perform_later).with(
+          amazon_topic,
+          "Source.availability_check",
+          a_hash_including(
+            :params => a_hash_including(
+              :source_id       => source.id.to_s,
+              :external_tenant => tenant.external_tenant
+            )
+          )
+        )
 
         post(check_availability_path(source.id), :headers => headers)
 
@@ -504,7 +500,7 @@ RSpec.describe("v3.1 - Sources") do
 
         source.applications = [app1, app2]
 
-        expect(messaging_client).not_to receive(:publish_topic)
+        expect(KafkaPublishJob).not_to receive(:perform_later)
 
         request_body = {:source_id => source.id.to_s}.to_json
 


### PR DESCRIPTION
Moar hackathon work...

the `POST /sources/:id/check_availability` operation can slow to an absolute crawl during the sources-monitor runs mostly due to the fact that it's producing a message for every source, which can balloon the average request time to 1-2 seconds.

By queuing them in sidekiq we can process them in parallel and most importantly *out of the request* so the request time is still wicked fast. 

cc @syncrou 

EDIT: I imported the CI db locally and ran a test to see how much faster this will be - I ran both checkers like so: 

```
time bash -c "bundle exec bin/availability_checker available && bundle exec bin/availability_checker unavailable" >/dev/null
```

the results are as such:
old code (produce message in the request): 
```
real    0m22.084s
user    0m1.631s 
sys     0m0.301s 
```

new code (with sidekiq taking a bit longer to process, but it produces 5 messages at once but not in the request):
```
real    0m5.298s 
user    0m1.577s 
sys     0m0.330s 
```

This will improve more once the tenancy prs are merged too! Should be great!