### PR TITLE
Retry connecting to the db if the listener runs into a connection error

### DIFF
--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -59,6 +59,11 @@ class AvailabilityStatusListener
     Rails.logger.error("Could not find #{model_class} with id #{record_id}")
   rescue ActiveRecord::RecordInvalid
     Rails.logger.error("Invalid status #{payload["status"]}")
+  rescue ActiveRecord::StatementInvalid, PG::UnableToSend
+    Rails.logger.error("Ran into error connecting to db - retrying.")
+    ActiveRecord::Base.establish_connection
+
+    retry
   rescue => e
     Rails.logger.error(["Something is wrong when processing Kafka message: ", e.message, *e.backtrace].join($RS))
   end


### PR DESCRIPTION
So I just noticed this on prod - the listener apparently lost connection to the db and since it's just running in a thread it apparently doesn't manually reconnect. 

The little handler there tries to re-establish the connection before failing _again_ and being caught by the final rescue clause again. This way if it's just a blip it'll reconnect and retry. 