### PR TITLE
Fix application delete for SuperKey Sources

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -114,8 +114,14 @@ class Application < ApplicationRecord
 
   def teardown_superkey_workflow
     return unless source.super_key? && source.super_key_credential
+    return if Redis.current.get("application_#{id}_delete_queued")
 
-    SuperkeyDeleteJob.perform_later(self) unless Redis.current.get("application_#{id}_delete_queued")
+    sk = Sources::SuperKey.new(
+      :provider    => source.source_type.name,
+      :source_id   => source.id,
+      :application => self
+    )
+    sk.teardown
   end
 
   def copy_superkey_data

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe("Application") do
         it "runs the superkey workflow" do
           _auth = Authentication.create!(:resource => source, :tenant => source.tenant, :username => "foo", :password => "bar")
           source.reload
-          expect(SuperkeyDeleteJob).to receive(:perform_later).with(application).once
+          expect(sk).to receive(:teardown)
 
           application.destroy!
         end


### PR DESCRIPTION
I totally forgot that I refactored that job after doing this section of the code - resulting in the callback straight up _not working_ when just deleting an application.

Deleting a Source (and all sub-applications) works fine, but deleting just an individual application doesn't work. This fixes that. 