### PR TITLE
Add PSK support

### DIFF
--- a/app/controllers/api/v3x1/applications_controller.rb
+++ b/app/controllers/api/v3x1/applications_controller.rb
@@ -4,7 +4,7 @@ module Api
       def pause
         app = Application.find(params.require(:application_id)).tap { |s| authorize(s) }
         app.discard!
-        AvailabilityMessageJob.perform_later("Application.pause", app.to_json, Insights::API::Common::Request.current_forwardable)
+        AvailabilityMessageJob.perform_later("Application.pause", app.to_json, Sources::Api::Request.current_forwardable)
 
         head 204
       end
@@ -12,7 +12,7 @@ module Api
       def unpause
         app = Application.find(params.require(:application_id)).tap { |s| authorize(s) }
         app.undiscard!
-        AvailabilityMessageJob.perform_later("Application.unpause", app.to_json, Insights::API::Common::Request.current_forwardable)
+        AvailabilityMessageJob.perform_later("Application.unpause", app.to_json, Sources::Api::Request.current_forwardable)
 
         head 202
       end

--- a/app/controllers/api/v3x1/sources_controller.rb
+++ b/app/controllers/api/v3x1/sources_controller.rb
@@ -5,7 +5,7 @@ module Api
         source = Source.find(params.require(:id)).tap { |s| authorize(s) }
 
         if source.super_key?
-          SuperkeyDeleteJob.perform_later(source, Insights::API::Common::Request.current_forwardable)
+          SuperkeyDeleteJob.perform_later(source, Sources::Api::Request.current_forwardable)
           head :accepted
         else
           source.destroy!
@@ -18,7 +18,7 @@ module Api
         # the after_discard callback on the Application model handles discarding the source.
         src.applications.each do |app|
           app.discard!
-          AvailabilityMessageJob.perform_later("Application.pause", app.to_json, Insights::API::Common::Request.current_forwardable)
+          AvailabilityMessageJob.perform_later("Application.pause", app.to_json, Sources::Api::Request.current_forwardable)
         end
 
         head 204
@@ -29,7 +29,7 @@ module Api
         # the after_discard callback on the Application model handles undiscarding the source.
         src.applications.each do |app|
           app.undiscard!
-          AvailabilityMessageJob.perform_later("Application.unpause", app.to_json, Insights::API::Common::Request.current_forwardable)
+          AvailabilityMessageJob.perform_later("Application.unpause", app.to_json, Sources::Api::Request.current_forwardable)
         end
 
         head 202

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::API
   private
 
   def with_current_request
-    Insights::API::Common::Request.with_request(request) do |current|
+    Sources::Api::Request.with_request(request) do |current|
       begin
         if Tenant.tenancy_enabled? && current.required_auth?
           tenant = if user.key.present? && user.account.present?
@@ -82,7 +82,7 @@ class ApplicationController < ActionController::API
   def raise_event_if(raise_event_allowed, event, payload)
     return unless raise_event_allowed
 
-    headers = Insights::API::Common::Request.current_forwardable
+    headers = Sources::Api::Request.current_forwardable
     Sources::Api::Events.raise_event_with_logging(event, payload, headers)
   end
 
@@ -189,9 +189,9 @@ class ApplicationController < ActionController::API
 
   def pundit_user
     @pundit_user ||= OpenStruct.new(
-      :request => Insights::API::Common::Request.current!,
-      :key     => Insights::API::Common::Request.current.headers['x-rh-sources-psk'],
-      :account => Insights::API::Common::Request.current.headers['x-rh-sources-account-number']
+      :request => Sources::Api::Request.current!,
+      :key     => Sources::Api::Request.current.headers['x-rh-sources-psk'],
+      :account => Sources::Api::Request.current.headers['x-rh-sources-account-number']
     )
   end
   alias user pundit_user

--- a/app/jobs/async_delete_job.rb
+++ b/app/jobs/async_delete_job.rb
@@ -4,7 +4,7 @@ class AsyncDeleteJob < ApplicationJob
   def perform(instance, headers)
     Sidekiq.logger.info("Destroying #{instance.class} #{instance.id}...")
 
-    Insights::API::Common::Request.with_request(:original_url => "noop", :headers => headers) do
+    Sources::Api::Request.with_request(:original_url => "noop", :headers => headers) do
       instance.destroy!
     end
   end

--- a/app/jobs/superkey_delete_job.rb
+++ b/app/jobs/superkey_delete_job.rb
@@ -2,7 +2,7 @@ class SuperkeyDeleteJob < ApplicationJob
   queue_as :default
 
   def perform(source, headers)
-    Insights::API::Common::Request.with_request(:original_url => "noop", :headers => headers) do
+    Sources::Api::Request.with_request(:original_url => "noop", :headers => headers) do
       source.applications.each do |app|
         sk = Sources::SuperKey.new(
           :provider    => source.source_type.name,

--- a/app/models/concerns/event_concern.rb
+++ b/app/models/concerns/event_concern.rb
@@ -83,8 +83,8 @@ module EventConcern
   end
 
   def safe_headers
-    return nil unless Insights::API::Common::Request.current
+    return nil unless Sources::Api::Request.current
 
-    Insights::API::Common::Request.current_forwardable
+    Sources::Api::Request.current_forwardable
   end
 end

--- a/app/policies/default_policy.rb
+++ b/app/policies/default_policy.rb
@@ -1,8 +1,9 @@
 class DefaultPolicy
-  attr_reader :user, :record
+  attr_reader :request, :key, :record
 
-  def initialize(user, record)
-    @user = user
+  def initialize(context, record)
+    @request = context.request
+    @key = context.key
     @record = record
   end
 
@@ -32,16 +33,30 @@ class DefaultPolicy
   def admin?
     return true unless Sources::RBAC::Access.enabled?
 
-    user.system.present? || user.user&.org_admin? || write_access?
+    # TODO: remove org_admin after everyone has moved over.
+    # Maybe even remove the `system` check
+    request.system.present? || request.user&.org_admin? || psk_matches? || write_access?
+  end
+
+  def psk_matches?
+    return false if self.class.pre_shared_key.nil?
+
+    self.class.pre_shared_key == key
+  end
+
+  def self.pre_shared_key
+    # memoizing as a class-var, defaulting to ""
+    @pre_shared_key ||= ENV.fetch("SOURCES_PSK", nil)
   end
 
   delegate :write_access?, :to => Sources::RBAC::Access
 
   class Scope
-    attr_reader :user, :scope
+    attr_reader :request, :key, :scope
 
-    def initialize(user, scope)
-      @user = user
+    def initialize(context, scope)
+      @request = context.request
+      @key = context.key
       @scope = scope
     end
 

--- a/app/policies/default_policy.rb
+++ b/app/policies/default_policy.rb
@@ -35,7 +35,7 @@ class DefaultPolicy
 
     # TODO: remove org_admin after everyone has moved over.
     # Maybe even remove the `system` check
-    request.system.present? || request.user&.org_admin? || psk_matches? || write_access?
+    psk_matches? || request.system.present? || request.user&.org_admin? || write_access?
   end
 
   def psk_matches?

--- a/app/policies/default_policy.rb
+++ b/app/policies/default_policy.rb
@@ -39,14 +39,14 @@ class DefaultPolicy
   end
 
   def psk_matches?
-    return false if self.class.pre_shared_key.nil?
+    return false if self.class.pre_shared_keys.nil?
 
-    self.class.pre_shared_key == key
+    self.class.pre_shared_keys.include?(key)
   end
 
-  def self.pre_shared_key
-    # memoizing as a class-var, defaulting to ""
-    @pre_shared_key ||= ENV.fetch("SOURCES_PSK", nil)
+  def self.pre_shared_keys
+    # memoizing as a class-var, defaulting to []
+    @pre_shared_keys ||= ENV.fetch("SOURCES_PSK", "").split(",")
   end
 
   delegate :write_access?, :to => Sources::RBAC::Access

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -32,7 +32,7 @@ module Sources
           :service => Sources::Api::ClowderConfig.kafka_topic("platform.sources.superkey-requests"),
           :event   => "create_application",
           :payload => payload,
-          :headers => Insights::API::Common::Request.current_forwardable
+          :headers => Sources::Api::Request.current_forwardable
         )
       end
 
@@ -53,7 +53,7 @@ module Sources
           :service => "platform.sources.superkey-requests",
           :event   => "destroy_application",
           :payload => payload,
-          :headers => Insights::API::Common::Request.current_forwardable
+          :headers => Sources::Api::Request.current_forwardable
         )
       end
 

--- a/lib/sources/api/request.rb
+++ b/lib/sources/api/request.rb
@@ -1,0 +1,15 @@
+module Sources
+  module Api
+    class Request < Insights::API::Common::Request
+      EXTRA_HEADERS = %w[x-rh-sources-account-number].freeze
+
+      def self.current_forwardable
+        super.tap do |headers|
+          EXTRA_HEADERS.each do |extra|
+            headers[extra] = current.headers[extra]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/rbac_spec.rb
+++ b/spec/requests/api/rbac_spec.rb
@@ -24,12 +24,50 @@ describe("RBAC requests") do
       allow(Sources::RBAC::Access).to receive(:enabled?).and_return(true)
     end
 
-    context "when the user has write access" do
-      before do
-        allow(Sources::RBAC::Access).to receive(:write_access?).and_return(true)
+    context "when no psk is present" do
+      context "when the user has write access" do
+        before do
+          allow(Sources::RBAC::Access).to receive(:write_access?).and_return(true)
+        end
+
+        it "allows the operation" do
+          expect(Sources::RBAC::Access).to receive(:enabled?).once
+          post("/api/v3.0/sources", :params => attributes.to_json, :headers => headers)
+
+          expect(response).to have_attributes(
+            :status      => 201,
+            :location    => "http://www.example.com/api/v3.0/sources/#{response.parsed_body["id"]}",
+            :parsed_body => a_hash_including(attributes)
+          )
+        end
       end
 
-      it "allows the operation" do
+      context "when the user does not have write access" do
+        before do
+          allow(Sources::RBAC::Access).to receive(:write_access?).and_return(false)
+        end
+
+        it "denies the operation" do
+          expect(Sources::RBAC::Access).to receive(:enabled?).once
+
+          post("/api/v3.0/sources", :params => attributes.to_json, :headers => headers)
+          expect(response).to have_attributes(
+            :status      => 403,
+            :location    => nil,
+            :parsed_body => {"errors"=>[{"status" => "403", "detail" => "You are not authorized to perform the create action for this source"}]}
+          )
+        end
+      end
+    end
+
+    context "with a psk and no x-rh-id" do
+      let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-sources-psk" => "1234", "x-rh-sources-account-number" => external_tenant} }
+
+      before do
+        allow(DefaultPolicy).to receive(:pre_shared_key).and_return("1234")
+      end
+
+      it "allows the request to go through" do
         expect(Sources::RBAC::Access).to receive(:enabled?).once
         post("/api/v3.0/sources", :params => attributes.to_json, :headers => headers)
 
@@ -37,23 +75,6 @@ describe("RBAC requests") do
           :status      => 201,
           :location    => "http://www.example.com/api/v3.0/sources/#{response.parsed_body["id"]}",
           :parsed_body => a_hash_including(attributes)
-        )
-      end
-    end
-
-    context "when the user does not have write access" do
-      before do
-        allow(Sources::RBAC::Access).to receive(:write_access?).and_return(false)
-      end
-
-      it "denies the operation" do
-        expect(Sources::RBAC::Access).to receive(:enabled?).once
-
-        post("/api/v3.0/sources", :params => attributes.to_json, :headers => headers)
-        expect(response).to have_attributes(
-          :status      => 403,
-          :location    => nil,
-          :parsed_body => {"errors"=>[{"status" => "403", "detail" => "You are not authorized to perform the create action for this source"}]}
         )
       end
     end

--- a/spec/requests/api/rbac_spec.rb
+++ b/spec/requests/api/rbac_spec.rb
@@ -64,7 +64,7 @@ describe("RBAC requests") do
       let(:headers) { {"CONTENT_TYPE" => "application/json", "x-rh-sources-psk" => "1234", "x-rh-sources-account-number" => external_tenant} }
 
       before do
-        allow(DefaultPolicy).to receive(:pre_shared_key).and_return("1234")
+        allow(DefaultPolicy).to receive(:pre_shared_keys).and_return(%w(1234))
       end
 
       it "allows the request to go through" do


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-12955

\# TODO:
- [x] specs
- [x] validate message producing works when authing with PSK, forge x-rh-identity if necessary!

**EDIT:** So, the biggest part about this is that we probably need to have backward compatibility with the x-rh-id header + the new PSK related headers. 

To get around this I overrode the `Insights::API::Common::Request.current_forwardable` class method to add any new fields we want to - currently just forwarding the account number since they will have the PSK mounted as a secret in their namespace. 

----

I am probably going to do the kafka availability status listener changes (no more required x-rh-id header, required account number) in a separate PR that way this one doesn't get huge. 

So this PR basically just adds internal communication via PSK and passes on the new headers when they are used. 