### PR TITLE
require both username + password on superkey authentications

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -17,6 +17,7 @@ class Authentication < ApplicationRecord
 
   before_validation :set_source
   validate :only_one_superkey, :if => proc { new_record? && source.super_key? }
+  validate :both_username_and_password, :if => proc { resource.kind_of?(Source) && source.super_key? }
 
   private
 
@@ -34,6 +35,12 @@ class Authentication < ApplicationRecord
 
     if source.authentications.any? { |auth| auth.authtype == superkey_authtype }
       errors.add(:only_one_superkey, "Only one Authentication of #{superkey_authtype} is allowed on the Source.")
+    end
+  end
+
+  def both_username_and_password
+    if username.nil? || password.nil?
+      errors.add(:both_username_and_password, "superkey authentications require both username and password")
     end
   end
 

--- a/spec/models/authentication_spec.rb
+++ b/spec/models/authentication_spec.rb
@@ -125,6 +125,10 @@ describe Authentication do
       it "allows updating the superkey record" do
         expect { authentication.update!(:username => "another thing") }.not_to raise_error
       end
+
+      it "requires username and password on authentication" do
+        expect { authentication.update!(:password => nil) }.to raise_error(ActiveRecord::RecordInvalid)
+      end
     end
   end
 end


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14557

API side implmenetation for this bug - for superkey we _NEED_ both username and password (access/secret keys in the case of AWS). This PR just adds a validation on that for superkey sources. 

We may need to revisit this in the future if there is a source type that only requires one, like an API key or something. 