### PR TITLE
Remove Topological Inventory ApplicationType

### DIFF
--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -1,8 +1,7 @@
 ---
 "/insights/platform/catalog":
   :display_name: Automation Services Catalog
-  :dependent_applications:
-  - "/insights/platform/topological-inventory"
+  :dependent_applications: []
   :supported_source_types:
   - ansible-tower
   :supported_authentication_types:
@@ -34,23 +33,6 @@
   :supported_authentication_types:
     amazon:
     - cloud-meter-arn
-"/insights/platform/topological-inventory":
-  :display_name: Topological Inventory
-  :dependent_applications: []
-  :supported_source_types:
-  - amazon
-  - ansible-tower
-  - azure
-  - openshift
-  :supported_authentication_types:
-    amazon:
-    - access_key_secret_key
-    ansible-tower:
-    - username_password
-    azure:
-    - tenant_id_client_id_client_secret
-    openshift:
-    - token
 "/insights/platform/fifi":
   :display_name: Remediations
   :dependent_applications: []

--- a/spec/models/application_type_spec.rb
+++ b/spec/models/application_type_spec.rb
@@ -1,3 +1,3 @@
 describe ApplicationType do
-  include_examples ".seed", :name => "/insights/platform/topological-inventory"
+  include_examples ".seed", :name => "/insights/platform/cost-management"
 end


### PR DESCRIPTION
Only question I have here - if it deletes the application type will it cascade delete all the applications in the DB that are topo?

EDIT:
Yep, looks like it does. 
```
[ remove_topo_application_type ⚛ ] ~/git/crc/sources/api $ rails c
Loading development environment (Rails 5.2.6)
[1] pry(main)> Application.count
   (0.4ms)  SELECT COUNT(*) FROM "applications"
=> 85

((( rake db:seed in another terminal )))

[2] pry(main)> Application.count
   (0.4ms)  SELECT COUNT(*) FROM "applications"
=> 76
```