### PR TITLE
Bump insights api common to 5.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gem 'cloudwatchlogger',     '~> 0.2.1'
 gem 'clowder-common-ruby',  '~> 0.2.2'
 gem 'discard',              '~> 1.2'
-gem 'insights-api-common',  '~> 5.0', '>= 5.0.4'
+gem 'insights-api-common',  '~> 5.0', '>= 5.0.5'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"


### PR DESCRIPTION
5.0.5 includes Support total counts for GraphQL https://github.com/RedHatInsights/insights-api-common-rails/pull/229 