### PR TITLE
Add support for SOURCES_PSKS secret if it exists in the namespace

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -94,6 +94,12 @@ objects:
           value: ${CLOUD_METER_API_SCHEME}://${CLOUD_METER_API_HOST}:${CLOUD_METER_SOURCES_API_PORT}${CLOUD_METER_SOURCES_API_AVAILABILITY_CHECK_PATH}
         - name: COST_MANAGEMENT_AVAILABILITY_CHECK_URL
           value: ${KOKU_SOURCES_API_SCHEME}://${KOKU_SOURCES_API_HOST}:${KOKU_SOURCES_API_PORT}${KOKU_SOURCES_API_APP_CHECK_PATH}
+        - name: SOURCES_PSKS
+          valueFrom:
+            secretKeyRef:
+              name: sources-psks
+              key: psks
+              optional: true
         - name: ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-14651

Clowdapp change for ^, the `optional: true` denotion basically says "still spin up the deployment even if the secret isn't there, otherwise we would end up with a pod initialization error.