### PR TITLE
pluralize SOURCES_PSKS env var read in DefaultPlicy to match ENV var

### DIFF
--- a/app/policies/default_policy.rb
+++ b/app/policies/default_policy.rb
@@ -46,7 +46,7 @@ class DefaultPolicy
 
   def self.pre_shared_keys
     # memoizing as a class-var, defaulting to []
-    @pre_shared_keys ||= ENV.fetch("SOURCES_PSK", "").split(",")
+    @pre_shared_keys ||= ENV.fetch("SOURCES_PSKS", "").split(",")
   end
 
   delegate :write_access?, :to => Sources::RBAC::Access


### PR DESCRIPTION
Me being the derp that I am edited it to plural `PSKS` everywhere except the actual code. 