### PR TITLE
Disallow update action for paused resources in API

### DIFF
--- a/app/controllers/api/v3x1.rb
+++ b/app/controllers/api/v3x1.rb
@@ -8,8 +8,6 @@ module Api
 
     class ApplicationTypesController < Api::V3x0::ApplicationTypesController; end
     class ApplicationAuthenticationsController < Api::V3x0::ApplicationAuthenticationsController; end
-    class AuthenticationsController  < Api::V3x0::AuthenticationsController; end
-    class EndpointsController        < Api::V3x0::EndpointsController; end
     class GraphqlController          < Api::V3x0::GraphqlController; end
     class SourceTypesController      < Api::V3x0::SourceTypesController; end
   end

--- a/app/controllers/api/v3x1/applications_controller.rb
+++ b/app/controllers/api/v3x1/applications_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V3x1
     class ApplicationsController < Api::V3x0::ApplicationsController
+      include Mixins::PausableMixin
+
       def pause
         app = Application.find(params.require(:application_id)).tap { |s| authorize(s) }
         app.discard!
@@ -15,6 +17,25 @@ module Api
         AvailabilityMessageJob.perform_later("Application.unpause", app.to_json, Sources::Api::Request.current_forwardable)
 
         head 202
+      end
+
+      def update
+        application = Application.find(params.require(:id))
+        authorize(application)
+
+        update_pausable(application) do |allowed_parameters_for_update|
+          application.update!(allowed_parameters_for_update)
+
+          # Here we're raising the create event after the worker has filled in the
+          # values for the source, but only the first time after the worker processes the message,
+          # from there on we raise the normal update.
+          first_time_superkey = (application.source.super_key? && params.try(:[], "extra")&.key?("_superkey"))
+          raise_event_if(first_time_superkey, "Application.create", application.as_json)
+          raise_event_if(first_time_superkey, "Records.create", application.bulk_message)
+
+          # appending the extra keys in case of _superkey being updated.
+          application.raise_event_for_update(allowed_parameters_for_update.keys + params.fetch("extra", {}).keys)
+        end
       end
     end
   end

--- a/app/controllers/api/v3x1/authentications_controller.rb
+++ b/app/controllers/api/v3x1/authentications_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V3x1
+    class AuthenticationsController < Api::V3x0::AuthenticationsController
+      include Mixins::UpdateMixin
+    end
+  end
+end

--- a/app/controllers/api/v3x1/endpoints_controller.rb
+++ b/app/controllers/api/v3x1/endpoints_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V3x1
+    class EndpointsController < Api::V3x0::EndpointsController
+      include Mixins::UpdateMixin
+    end
+  end
+end

--- a/app/controllers/api/v3x1/mixins/pausable_mixin.rb
+++ b/app/controllers/api/v3x1/mixins/pausable_mixin.rb
@@ -1,0 +1,67 @@
+module Api
+  module V3x1
+    module Mixins
+      module PausableMixin
+        ALLOWED_ATTRIBUTES_FOR_PAUSED_RESOURCES = %w[
+          availability_status
+          availability_status_error
+          last_checked_at
+          last_available_at
+        ].freeze
+
+        def update_pausable(record)
+          raise ArgumentError, "Method requires block" unless block_given?
+
+          if allowed_update_keys_for(record).empty?
+            response = {:status => "422", :detail => failure_message_message_for_unpermitted(params_for_update)}
+            render :json => {:errors => [response]}, :status => :unprocessable_entity
+          else
+            yield(allowed_parameters_for_update(record))
+
+            if partial_update?(record)
+              render :json => partial_update_response(allowed_parameters_for_update(record)), :status => :multi_status
+            else
+              head :no_content
+            end
+          end
+        end
+
+        private
+
+        def partial_update?(record)
+          params_for_update.keys.count != allowed_parameters_for_update(record).keys.count
+        end
+
+        def allowed_parameters_for_update(record)
+          params_for_update.slice(*allowed_update_keys_for(record))
+        end
+
+        def allowed_update_keys_for(record)
+          update_parameters = params_for_update.keys
+          paused?(record) ? update_parameters & allowed_attributes_to_update_for_model : update_parameters
+        end
+
+        def failure_message_message_for_unpermitted(parameters)
+          "Found unpermitted parameters: #{parameters.keys.sort.join(', ')}"
+        end
+
+        def partial_update_response(allowed_parameters)
+          success_message = "Listed parameters in 'resource' has been updated successfully."
+          success_results = [{:detail => success_message, :resource => allowed_parameters, :status => 200}]
+
+          disallowed_parameters = params_for_update.except(*allowed_parameters.keys)
+          error_message = failure_message_message_for_unpermitted(disallowed_parameters)
+          {:results => success_results, :errors => [{:detail => error_message, :status => 422 }]}
+        end
+
+        def allowed_attributes_to_update_for_model
+          model.attribute_names & ALLOWED_ATTRIBUTES_FOR_PAUSED_RESOURCES
+        end
+
+        def paused?(record)
+          model.include?(Pausable) && record.discarded?
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3x1/mixins/update_mixin.rb
+++ b/app/controllers/api/v3x1/mixins/update_mixin.rb
@@ -1,0 +1,19 @@
+module Api
+  module V3x1
+    module Mixins
+      module UpdateMixin
+        include Mixins::PausableMixin
+
+        def update
+          record = model.find(params.require(:id))
+          authorize(record)
+
+          update_pausable(record) do |allowed_parameters_for_update|
+            record.update!(allowed_parameters_for_update)
+            record.raise_event_for_update(allowed_parameters_for_update.keys)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3x1/sources_controller.rb
+++ b/app/controllers/api/v3x1/sources_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V3x1
     class SourcesController < Api::V3x0::SourcesController
+      include Mixins::UpdateMixin
+
       def destroy
         source = Source.find(params.require(:id)).tap { |s| authorize(s) }
 

--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -433,7 +433,7 @@
       "patch": {
         "summary": "Update an existing Application",
         "operationId": "updateApplication",
-        "description": "Updates a Application object",
+        "description": "Updates a Application object.\n\nIn case Application object is paused then allowed attributes for update action are: \n\n `availability_status, availability_status_error, last_checked_at, last_available_at`",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -454,6 +454,16 @@
           "204": {
             "description": "Updated, no content"
           },
+          "207" : {
+            "description": "Multi-status, some parameters are unpermitted due to paused resource(or related) but some parameters are valid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartialUpdateResponse"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad request"
           },
@@ -463,6 +473,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity due to paused resource or paused related resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorUnpermittedParameters"
                 }
               }
             }
@@ -698,7 +718,7 @@
       "patch": {
         "summary": "Update an existing Authentication",
         "operationId": "updateAuthentication",
-        "description": "Updates a Authentication object",
+        "description": "Updates a Authentication object.\n\nIn case Authentication object is paused then allowed attributes for update action are: \n\n `availability_status, availability_status_error, last_checked_at, last_available_at`",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -719,6 +739,16 @@
           "204": {
             "description": "Updated, no content"
           },
+          "207" : {
+            "description": "Multi-status, some parameters are unpermitted due to paused resource(or related) but some parameters are valid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartialUpdateResponse"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad request"
           },
@@ -728,6 +758,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity due to paused resource or paused related resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorUnpermittedParameters"
                 }
               }
             }
@@ -857,7 +897,7 @@
       "patch": {
         "summary": "Update an existing Endpoint",
         "operationId": "updateEndpoint",
-        "description": "Updates a Endpoint object",
+        "description": "Updates a Endpoint object.\n\nIn case Endpoint object is paused then allowed attributes for update action are: \n\n `availability_status, availability_status_error, last_checked_at, last_available_at`",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -878,6 +918,16 @@
           "204": {
             "description": "Updated, no content"
           },
+          "207" : {
+            "description": "Multi-status, some parameters are unpermitted due to paused resource(or related) but some parameters are valid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartialUpdateResponse"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad request"
           },
@@ -887,6 +937,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity due to paused resource or paused related resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorUnpermittedParameters"
                 }
               }
             }
@@ -1223,7 +1283,7 @@
       "patch": {
         "summary": "Update an existing Source",
         "operationId": "updateSource",
-        "description": "Updates a Source object",
+        "description": "Updates a Source object.\n\nIn case Source object is paused then allowed attributes for update action are: \n\n `availability_status, last_checked_at, last_available_at`",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -1244,6 +1304,16 @@
           "204": {
             "description": "Updated, no content"
           },
+          "207" : {
+            "description": "Multi-status, some parameters are unpermitted due to paused resource(or related) but some parameters are valid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartialUpdateResponse"
+                }
+              }
+            }
+          },
           "400": {
             "description": "Bad request"
           },
@@ -1253,6 +1323,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorNotFound"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity due to paused resource or paused related resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorUnpermittedParameters"
                 }
               }
             }
@@ -2513,6 +2593,73 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/Authentication"
+            }
+          }
+        }
+      },
+      "ErrorUnpermittedParameters": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "422"
+                },
+                "detail": {
+                  "type": "string",
+                  "example": "Found unpermitted parameters: xxx, yyy"
+                }
+              }
+            }
+          }
+        }
+      },
+      "PartialUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "422"
+                },
+                "detail": {
+                  "type": "string",
+                  "example": "Found unpermitted parameters: xxx, yyy"
+                }
+              }
+            }
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "example": "200"
+                },
+                "detail": {
+                  "type": "string",
+                  "example": "Listed parameters in 'resource' has been updated successfully."
+                },
+                "resource": {
+                  "type": "object",
+                  "properties": {
+                    "availability_status": {
+                      "type": "string",
+                      "example": "available"
+                    }
+                  }
+                }
+              }
             }
           }
         }

--- a/spec/requests/api/v3.1/applications_spec.rb
+++ b/spec/requests/api/v3.1/applications_spec.rb
@@ -135,6 +135,10 @@ RSpec.describe("v3.1 - Applications") do
           :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
+
+      context "paused resources" do
+        include_examples "updating paused resource", Application
+      end
     end
 
     context "delete" do

--- a/spec/requests/api/v3.1/authentications_spec.rb
+++ b/spec/requests/api/v3.1/authentications_spec.rb
@@ -163,6 +163,10 @@ RSpec.describe("v3.1 - Authentications") do
           :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
+
+      context "paused resources" do
+        include_examples "updating paused resource", Authentication
+      end
     end
 
     context "delete" do

--- a/spec/requests/api/v3.1/endpoints_spec.rb
+++ b/spec/requests/api/v3.1/endpoints_spec.rb
@@ -147,6 +147,10 @@ RSpec.describe("v3.1 - Endpoints") do
           :parsed_body => {"errors" => [{"detail" => "Record not found", "status" => "404"}]}
         )
       end
+
+      context "paused resources" do
+        include_examples "updating paused resource", Endpoint
+      end
     end
 
     context "delete" do

--- a/spec/requests/api/v3.1/sources_spec.rb
+++ b/spec/requests/api/v3.1/sources_spec.rb
@@ -335,6 +335,10 @@ RSpec.describe("v3.1 - Sources") do
           :parsed_body => {"errors" => [{"detail" => "ActionController::UnpermittedParameters: found unpermitted parameter: :created_at", "status" => "400"}]}
         )
       end
+
+      context "paused resources" do
+        include_examples "updating paused resource", Source
+      end
     end
 
     context "delete" do

--- a/spec/support/requests_shared_examples.rb
+++ b/spec/support/requests_shared_examples.rb
@@ -1,0 +1,108 @@
+RSpec.shared_examples_for "updating paused resource" do |model_klass|
+  let(:origin_values) do
+    {'name'                      => "Origin Name",
+     'certificate_authority'     => "Origin Auth",
+     'extra'                     => { "azure" => {"tenant_id" => "1" }},
+     'availability_status'       => "available",
+     'availability_status_error' => nil,
+     'last_checked_at'           => nil,
+     'last_available_at'         => nil
+    }
+  end
+
+  let(:new_values_for_disallowed_attributes) do
+    {'name'                  => "New Name",
+     'certificate_authority' => "New Auth",
+     'extra'                 => { "azure" => { "tenant_id" => "3" }},
+    }
+  end
+
+  let(:new_values_for_allowed_attributes) do
+    {
+      'availability_status'       => "unavailable",
+      'availability_status_error' => "error",
+      'last_checked_at'           => Time.parse("03-03-2021 18:00"),
+      'last_available_at'         => Time.parse("03-03-2021 19:00")
+    }
+  end
+
+  def instance_attributes_for(model, mock_values)
+    model_attributes = model.attribute_names & origin_values.keys
+    mock_values.slice(*model_attributes)
+  end
+
+  let(:application) { create(:application, :tenant => tenant) }
+
+  let(:authentication_payload) do
+    {
+      "username"      => "test_name",
+      "password"      => "Test Password",
+      "resource_type" => "Application",
+      "resource_id"   => application.id.to_s
+    }
+  end
+
+  let(:instance) do
+    instance_attributes = instance_attributes_for(model_klass, origin_values)
+    instance_attributes.merge!(authentication_payload) if model_klass == Authentication
+    create(model_klass.name.tableize.singularize, instance_attributes.merge(:tenant => tenant))
+  end
+
+  before do
+    instance.discard
+  end
+
+  it "rejects update action of disallowed attributes by pausing a #{model_klass}" do
+    new_attributes = instance_attributes_for(model_klass, new_values_for_disallowed_attributes)
+
+    patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+    response_message = "Found unpermitted parameters: #{new_attributes.keys.sort.join(', ')}"
+    expected_parsed_body = {"errors" => [{"detail" => response_message, "status" => "422"}]}
+    expect(response).to have_attributes(:status => 422, :parsed_body => expected_parsed_body)
+
+    instance.reload
+
+    instance_attributes = instance.attributes
+    instance_attributes_for(model_klass, origin_values).each do |key, value|
+      expect(instance_attributes[key]).to eq(value)
+    end
+  end
+
+  it "rejects update action of disallowed attributes by pausing a #{model_klass} and updates allowed attributes" do
+    update_attributes = new_values_for_disallowed_attributes.merge(new_values_for_allowed_attributes)
+    new_attributes = instance_attributes_for(model_klass, update_attributes)
+
+    patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+    response_message = "Listed parameters in 'resource' has been updated successfully."
+    resource_parameters = instance_attributes_for(model_klass, new_values_for_allowed_attributes)
+    result = {'detail' => response_message, 'resource' => resource_parameters, 'status' => 200}
+    unpermitted_parameters = new_attributes.except(*new_values_for_allowed_attributes.keys)
+    expected_parsed_body = {"results"=> [result], "errors" => [{"detail"=>"Found unpermitted parameters: #{unpermitted_parameters.keys.sort.join(', ')}", "status" => 422}]}
+
+    expect(response).to have_attributes(:status => 207, :parsed_body => expected_parsed_body)
+
+    instance.reload
+
+    instance_attributes = instance.attributes
+    instance_attributes_for(model_klass, origin_values.merge(new_values_for_allowed_attributes)).each do |key, value|
+      expect(instance_attributes[key]).to eq(value)
+    end
+  end
+
+  it "updates paused resource with allowed attributes" do
+    new_attributes = instance_attributes_for(model_klass, new_values_for_allowed_attributes)
+
+    patch(instance_path(instance.id), :params => new_attributes.to_json, :headers => headers)
+
+    expect(response).to have_attributes(:status => 204)
+
+    instance.reload
+
+    instance_attributes = instance.attributes
+    instance_attributes_for(model_klass, new_values_for_allowed_attributes).each do |key, value|
+      expect(instance_attributes[key]).to eq(value)
+    end
+  end
+end


### PR DESCRIPTION
**WIP reason - dependent PR:** 
- [x] https://github.com/RedHatInsights/sources-api/pull/424

- done for **Authentications, Applications, Endpoints and Sources**
- Update action is still allowed for attributes(if exists on the model): `availability_status, availability_status_error, last_checked_at, last_available_at`
- Responses (if resource is paused, success as usual 204):

###  1. All attributes are disallowed to update:
```
PATCH /api/sources/v3.1/applications/5
{ 
  "extra": { }
}

Response 422 Multi-Status:
{
    "errors": [
        {
            "status": "422",
            "detail": "Found unpermitted parameters: extra"
        }
    ]
}
```
###  2. Some attributes are disallowed to update and some attributes are allowed to update:
```
PATCH /api/sources/v3.1/applications/5

{ 
  "availability_status": "available",
  "extra": { }
}

Response 207 Multi-Status:
{
    "results": [
        {
            "detail": "Listed parameters in 'resource' has been updated successfully.",
            "resource": {
                "availability_status": "available"
            },
            "status": 200
        }
    ],
    "errors": [
        {
            "detail": "Found unpermitted parameters: extra",
            "status": 422
        }
    ]
}

```

### Links

- https://issues.redhat.com/browse/RHCLOUD-14479

