### PR TITLE
Add pausable mixin to endpoint

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -136,7 +136,10 @@ class Application < ApplicationRecord
   def discard_workflow
     authentications.discard_all
     application_authentications.discard_all
-    source.discard if Application.where(:source_id => source_id).all?(&:discarded?)
+    if Application.where(:source_id => source_id).all?(&:discarded?)
+      source.discard
+      source.endpoints.discard_all
+    end
   end
 
   # inverse of above.
@@ -144,5 +147,6 @@ class Application < ApplicationRecord
     authentications.undiscard_all
     application_authentications.undiscard_all
     source.undiscard
+    source.endpoints.undiscard_all
   end
 end

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,4 +1,5 @@
 class Endpoint < ApplicationRecord
+  include Pausable
   include TenancyConcern
   include EventConcern
   include AvailabilityStatusConcern

--- a/db/migrate/20210701105323_add_paused_at_to_endpoints.rb
+++ b/db/migrate/20210701105323_add_paused_at_to_endpoints.rb
@@ -1,0 +1,6 @@
+class AddPausedAtToEndpoints < ActiveRecord::Migration[5.2]
+  def change
+    add_column :endpoints, :paused_at, :datetime
+    add_index :endpoints, :paused_at
+  end
+end

--- a/spec/requests/api/v3.1/applications_spec.rb
+++ b/spec/requests/api/v3.1/applications_spec.rb
@@ -215,6 +215,7 @@ RSpec.describe("v3.1 - Applications") do
       instance.reload
       expect(instance.send(check_method)).to be_truthy
       expect(instance.source.send(check_method)).to be_truthy
+      expect(instance.source.endpoints.map(&check_method).all?).to be_truthy
       expect(instance.authentications.map(&check_method).all?).to be_truthy
       expect(instance.application_authentications.map(&check_method).all?).to be_truthy
     end

--- a/spec/requests/api/v3.1/sources_spec.rb
+++ b/spec/requests/api/v3.1/sources_spec.rb
@@ -548,6 +548,7 @@ RSpec.describe("v3.1 - Sources") do
     def expect_pausable_relations(check_method)
       instance.reload
       expect(instance.send(check_method)).to be_truthy
+      expect(instance.endpoints.map(&check_method).all?).to be_truthy
       expect(instance.applications.map(&check_method).all?).to be_truthy
       authentications = instance.applications.map(&:authentications).flatten
       expect(authentications.map(&check_method).all?).to be_truthy


### PR DESCRIPTION
- improve spec for pausing
- migration which adds `paused_at` to `endpoints` table
- changed `Aplication#[un]discard_workflow` methods to [un]discard also endpoints

