### PR TITLE
Add sidekiq_alive gem as a liveness probe for sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'pundit',               '~> 2.1'
 gem 'rack-cors',            '>= 1.1.1', '~> 1.1'
 gem 'rails',                '~> 5.2.2'
 gem 'sidekiq',              '~> 5.2.2'
+gem 'sidekiq_alive',        '~> 2.1.0'
 gem 'sprockets',            '~> 4.0'
 
 group :development, :test do

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -58,6 +58,14 @@ objects:
           requests:
             cpu: ${SIDEKIQ_CPU_REQUEST}
             memory: ${SIDEKIQ_MEMORY_REQUEST}
+        readinessProbe:
+          tcpSocket:
+            port: 7433
+          initialDelaySeconds: 5
+        livenessProbe:
+          httpGet:
+            port: 7433
+          initialDelaySeconds: 10
     - name: svc
       minReplicas: ${{MIN_REPLICAS}}
       webServices:


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-15152

`sidekiq_alive` is a nice little gem that does exactly what I was going to try and do by myself which is basically:
1. Set up a queue for monitoring completed jobs
2. If jobs are failing to get processed -> quit updating the queue
3. If the queue hasn't been updated in a while -> return a 500 on a http port

Initially i was just going to touch files (like I did in Superkey) but this gem is self contained and easy. 

cc @syncrou 