### PR TITLE
Use insights-logger-ruby gem through insights-api-common

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gem 'cloudwatchlogger',     '~> 0.2.1'
 gem 'clowder-common-ruby',  '~> 0.2.2'
 gem 'discard',              '~> 1.2'
-gem 'insights-api-common',  '~> 5.0', '>= 5.0.5'
+gem 'insights-api-common',  '~> 5.0', '>= 5.0.6'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
 gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,6 @@ module Sources
     config.autoload_paths << Rails.root.join("app", "policies", "mixins").to_s
     config.autoload_paths << Rails.root.join("lib").to_s
 
-    config.log_level = (ENV['RAILS_LOG_LEVEL'] || 'debug').downcase.to_sym
     Insights::API::Common::Logging.activate(config)
 
     # ManageIQ Metrics depends on these variables

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -31,8 +31,10 @@ objects:
           value: ${APP_NAME}
         - name: DB_POOL_SIZE
           value: ${SIDEKIQ_DB_POOL_SIZE}
-        - name: RAILS_LOG_LEVEL
+        - name: LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: CONTAINER_LOG_LEVEL
+          value: ${CONTAINER_LOG_LEVEL}
           # TODO: It never can be blank!
         - name: CLOUD_METER_AVAILABILITY_CHECK_URL
           value: ${CLOUD_METER_SOURCES_API_SCHEME}://${CLOUD_METER_API_HOST}:${CLOUD_METER_SOURCES_API_PORT}${CLOUD_METER_SOURCES_API_AVAILABILITY_CHECK_PATH}
@@ -89,8 +91,10 @@ objects:
           value: ${APP_NAME}
         - name: DB_POOL_SIZE
           value: ${DB_POOL_SIZE}
-        - name: RAILS_LOG_LEVEL
+        - name: LOG_LEVEL
           value: ${LOG_LEVEL}
+        - name: CONTAINER_LOG_LEVEL
+          value: ${CONTAINER_LOG_LEVEL}
         - name: CLOUD_METER_AVAILABILITY_CHECK_URL
           value: ${CLOUD_METER_API_SCHEME}://${CLOUD_METER_API_HOST}:${CLOUD_METER_SOURCES_API_PORT}${CLOUD_METER_SOURCES_API_AVAILABILITY_CHECK_PATH}
         - name: COST_MANAGEMENT_AVAILABILITY_CHECK_URL
@@ -223,6 +227,8 @@ parameters:
   value: /api/cost-management/v1/source-status/
 - name: LOG_LEVEL
   value: WARN
+- name: CONTAINER_LOG_LEVEL
+  value: INFO
 - name: MEMORY_LIMIT
   value: 1Gi
 - name: MEMORY_REQUEST


### PR DESCRIPTION
NOTE: I expect that next version of insights-api-common will be 5.0.6. But now it doesn't exists yet.

REQUIRED:
- [x] https://github.com/RedHatInsights/insights-api-common-rails/pull/225

### Links
https://issues.redhat.com/browse/RHCLOUD-15151

