### PR TITLE
Generate `x-rh-sources-account-number` header when not present

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -12,7 +12,7 @@ objects:
   stringData:
     encryption-key: "${ENCRYPTION_KEY}"
     secret-key: "${SECRET_KEY}"
-    psks: "${PSK}"
+    psks: "thisMustBeEphemeralOrMinikube"
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
@@ -275,12 +275,6 @@ parameters:
   required: true
   description: Rails SECRET_KEY_BASE
   from: "[a-f0-9]{128}"
-  generate: expression
-- name: PSK
-  displayName: PSK (Ephemeral)
-  required: true
-  description: Sources API PSK
-  from: "[a-f0-9]{16}"
   generate: expression
 - description: Env name for seed
   name: SOURCES_ENV

--- a/lib/availability_status_listener.rb
+++ b/lib/availability_status_listener.rb
@@ -40,7 +40,8 @@ class AvailabilityStatusListener
     return unless event.message == EVENT_AVAILABILITY_STATUS
 
     # backwards compability for now while people move over to psk, this way we don't skip messages missing the x-rh-id header
-    if event.headers["x-rh-sources-account-number"]
+    # we also don't want to overwrite the x-rh-id _if its there_
+    if event.headers["x-rh-sources-account-number"] && !event.headers["x-rh-identity"]
       event.headers["x-rh-identity"] = Base64.strict_encode64(
         JSON.dump(
           {

--- a/lib/sources/api/request.rb
+++ b/lib/sources/api/request.rb
@@ -1,12 +1,17 @@
 module Sources
   module Api
     class Request < Insights::API::Common::Request
-      EXTRA_HEADERS = %w[x-rh-sources-account-number].freeze
+      # map of extra headers mapping with a name as well as a function to get the value if it isn't present already.
+      # this is currently only useful for the account-number changes since we need that account number to be present
+      # on the kafka messages even if the request came from outside (e.g. 3scale)
+      EXTRA_HEADERS = {
+        "x-rh-sources-account-number" => proc { Sources::Api::Request.current.identity["identity"]["account_number"] }
+      }.freeze
 
       def self.current_forwardable
         super.tap do |headers|
-          EXTRA_HEADERS.each do |extra|
-            headers[extra] = current.headers[extra]
+          EXTRA_HEADERS.each do |name, func|
+            headers[name] = (current.headers[name] || func.call)
           end
         end
       end


### PR DESCRIPTION
A few things found while doing integration work with swatch + cost:
1. The fact that the PSK changes _on every deploy_ is kind of a PITA in reality, so I'm changing the resource to always use the same string: `thisMustBeEphemeralOrMinikube`. Open to a funnier name if you have one!
2. Cost management still needs the x-rh-identity for some of the other fields in it (who would have thought that not only the account number would be used right?) so I changed the availability status listener to not overwrite it if present.
3. And the most important oversight I made during development was that I forgot that yes, sometime stuff can come from the outside still and those requests *will not* have the `x-rh-sources-account-number` header, so we need to reach into the `x-rh-identity` and pull out the account number so we can populate the internal header. This will only happen if the sources header isn't there but the x-rh-id is.

cc @maskarb @abellotti changes here for the account-number header generation on reqs/messages _without_ the x-rh-sources-account-number header.