### PR TITLE
validate that both x-rh-sources-account-number and x-rh-identity are always present.

### DIFF
--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -72,5 +72,26 @@ RSpec.describe AvailabilityStatusListener do
         subject.subscribe_to_availability_status
       end
     end
+
+    context "with x-rh-identity" do
+      let(:headers) { {"SECRET_HEADER" => "PASSWORD", "x-rh-identity" => xrhid} }
+      let(:endpoint) { create(:endpoint, :role => "first", :default => true) }
+      let(:resource_type) { "endpoint" }
+      let(:resource_id)   { endpoint.id.to_s }
+      let(:xrhid) do
+        Base64.strict_encode64(
+          JSON.dump(:identity => {
+                      :account_number => "1234",
+                      :user           => {:is_org_admin => true}
+                    })
+        )
+      end
+
+      it "enqueues the avialability status update job with both x-rh-id + x-rh-sources-account_number" do
+        expect(AvailabilityStatusUpdateJob).to receive(:perform_later).with(payload, headers.merge!("x-rh-sources-account-number" => "1234")).once
+
+        subject.subscribe_to_availability_status
+      end
+    end
   end
 end

--- a/spec/lib/availability_status_listener_spec.rb
+++ b/spec/lib/availability_status_listener_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe AvailabilityStatusListener do
     context "with the availability_status event_type" do
       it "enqueues the AvailabilityStatusUpdateJob" do
         expect(AvailabilityStatusUpdateJob).to receive(:perform_later).with(payload, headers).once
+        expect(Sources::Api::Request).to receive(:ensure_psk_and_rhid).once
 
         subject.subscribe_to_availability_status
       end


### PR DESCRIPTION
Fleshing this out a little more - there apparently are cases where x-rh-identity is not there but x-rh-sources-account-number is _but some want both all the time for now_. So this PR validates we have both of them on the availability status listener side as well as the forwardable headers side.