### PR TITLE
Lookup superkey-requests queue from clowder during delete

### DIFF
--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -50,7 +50,7 @@ module Sources
         }
 
         client.publish_topic(
-          :service => "platform.sources.superkey-requests",
+          :service => Sources::Api::ClowderConfig.kafka_topic("platform.sources.superkey-requests"),
           :event   => "destroy_application",
           :payload => payload,
           :headers => Sources::Api::Request.current_forwardable


### PR DESCRIPTION
Found this while debugging why my superkey deletions weren't working locally. Must have missed this during code review during clowderization. 

Probalby not hitting us on stage/prod since the topic names = the requested names, but it wasn't working on local!