### PR TITLE
Add vendor/ dir to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ v2_key
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/


### PR DESCRIPTION
This makes building + pushing images much faster due to not packaging the vendor directory in the image. 
