### PR TITLE
Skip exporting prometheus metrics if running rails console

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,6 @@ module Sources
     require "sources/api/clowder_config"
     ENV['METRICS_PORT'] = Sources::Api::ClowderConfig.instance['metricsPort'].to_s
 
-    Insights::API::Common::Metrics.activate(config, "sources_api")
+    Insights::API::Common::Metrics.activate(config, "sources_api") unless defined?(::Rails::Console)
   end
 end

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,6 +1,6 @@
 require "sources/api/clowder_config"
 
-if !Rails.env.test? && Sources::Api::ClowderConfig.instance['metricsPort'].to_s != '0'
+if !Rails.env.test? && !defined?(::Rails::Console) && Sources::Api::ClowderConfig.instance['metricsPort'].to_s != '0'
   require 'prometheus_exporter/middleware'
 
   # This reports stats per request like HTTP status and timings


### PR DESCRIPTION
Ran into this a bunch last week - if you exec into a pod on eph or minikube there will be log messages saying "Failed to bind to port" over and over again because the pod is re-trying to setup the prometheus exporter. 

This prevents that from happening which makes `rails c`'ing into a pod cleaner.
