### PR TITLE
Change `forwardable_headers` logic to skip the superclass since it is meant for x-rh-id

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -77,8 +77,9 @@ class Application < ApplicationRecord
 
   def availability_check_headers
     {
-      "Content-Type"  => "application/json",
-      "x-rh-identity" => Base64.strict_encode64({'identity' => {'account_number' => source.tenant.external_tenant}}.to_json)
+      "Content-Type"                => "application/json",
+      "x-rh-identity"               => Base64.strict_encode64({'identity' => {'account_number' => source.tenant.external_tenant}}.to_json),
+      "x-rh-sources-account-number" => source.tenant.external_tenant
     }
   end
 

--- a/lib/sources/api/request.rb
+++ b/lib/sources/api/request.rb
@@ -1,10 +1,16 @@
 module Sources
   module Api
     class Request < Insights::API::Common::Request
+      FORWARDABLE_HEADERS = Insights::API::Common::Request::FORWARDABLE_HEADER_KEYS + ["x-rh-sources-account-number"]
+
+      # overwriting the super method with the same code - since we can't overwrite the
+      # FORWARDABLE_HEADER_KEYS array in the superclass.
       def self.current_forwardable
-        super.tap do |headers|
-          ensure_psk_and_rhid(headers)
+        forwarding = FORWARDABLE_HEADERS.each_with_object({}) do |key, hash|
+          hash[key] = current.headers[key] if current.headers.key?(key)
         end
+
+        ensure_psk_and_rhid(forwarding)
       end
 
       def self.ensure_psk_and_rhid(headers)


### PR DESCRIPTION
also add x-rh-sources-account-number to the availability-check headers when requesting an application availability check
