### PR TITLE
add sources-psk secret to eph env for users to consume exactly like s…

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -21,6 +21,14 @@ objects:
       app: sources-api
   stringData:
     psk: "thisMustBeEphemeralOrMinikube"
+- apiVersion: v1
+  kind: Secret # For ephemeral/local environment
+  metadata:
+    name: sources-psk
+    labels:
+      app: sources-api
+  stringData:
+    psk: "thisMustBeEphemeralOrMinikube"
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:


### PR DESCRIPTION
…tage/prod

So this was a problem for people consuming our app in the ephemeral environment - while sources has the `sources-api-secrets/psks` to store the psks we care about, we also have the `internal-psk` for the superkey worker + the sources-monitor application to use. 

I seemed to forget that I need to *also* create the `sources-psk` secret so our dependents (subswatch, cost, etc) can consume it in the same way as stage/prod. 

This PR removes the need for logic on where the secret is. Sorry that I missed this.