### PR TITLE
pin miq loggers ro 0.4.x line since 0.7.0 breaks insights-api-common container logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'discard',              '~> 1.2'
 gem 'insights-api-common',  '~> 5.0', '>= 5.0.6'
 gem 'jbuilder',             '~> 2.0'
 gem 'json-schema',          '~> 2.8'
-gem 'manageiq-loggers',     '~> 0.4', ">= 0.4.2"
+gem 'manageiq-loggers',     '~> 0.4.0', ">= 0.4.2"
 gem 'manageiq-messaging',   '~> 1.0.0'
 gem 'manageiq-password',    '~> 0.2', ">= 0.2.1"
 gem 'more_core_extensions', '~> 3.5'


### PR DESCRIPTION
seeing this on the eph env (test failure on #446), but luckily this didn't hit stage/prod yet because we didn't promote:
```
RDS Cert Path: /opt/rdsca.crt
== Writing encryption key ==
== Checking sources-api-db.default.svc:5432 status ==
sources-api-db.default.svc:5432 - accepting connections
rake aborted!
NoMethodError: undefined method `call' for nil:NilClass
/usr/share/gems/gems/insights-loggers-ruby-0.1.10/lib/insights/loggers/container.rb:14:in `level='
/usr/share/gems/gems/manageiq-loggers-0.7.0/lib/manageiq/loggers/base.rb:13:in `initialize'
/usr/share/gems/gems/manageiq-loggers-0.7.0/lib/manageiq/loggers/container.rb:7:in `initialize'
/usr/share/gems/gems/insights-loggers-ruby-0.1.10/lib/insights/loggers/container.rb:8:in `initialize'
/usr/share/gems/gems/insights-loggers-ruby-0.1.10/lib/insights/loggers/cloud_watch.rb:15:in `new'
/usr/share/gems/gems/insights-loggers-ruby-0.1.10/lib/insights/loggers/cloud_watch.rb:15:in `new'
/usr/share/gems/gems/insights-loggers-ruby-0.1.10/lib/insights/loggers/factory.rb:19:in `logger_builder'
/usr/share/gems/gems/insights-loggers-ruby-0.1.10/lib/insights/loggers/factory.rb:9:in `create_logger'
/usr/share/gems/gems/insights-api-common-5.0.6/lib/insights/api/common/logging.rb:25:in `activate'
---snip
```

Basically our shim [here](https://github.com/RedHatInsights/insights-loggers-ruby/blob/800c6e4c4ae615e8c83cc7f278f5780265027b14/lib/insights/loggers/container.rb#L14) no longer works since they allow `level=` in the newer versions. Rather than fix the insights-logger gem we can just pin this since it works. 
