### PR TITLE
[wip] Lock down cert-auth's viewing to only source/endpionts + the satellite source type

### DIFF
--- a/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/app/controllers/api/v1/mixins/index_mixin.rb
@@ -3,6 +3,8 @@ module Api
     module Mixins
       module IndexMixin
         def index
+          authorize(filtered.new)
+
           raise_unless_primary_instance_exists
           render :json => Insights::API::Common::PaginatedResponse.new(
             :base_query => scoped(filtered.where(params_for_list)),

--- a/app/controllers/api/v1/mixins/show_mixin.rb
+++ b/app/controllers/api/v1/mixins/show_mixin.rb
@@ -3,6 +3,8 @@ module Api
     module Mixins
       module ShowMixin
         def show
+          authorize(model.new)
+
           render json: model.find(params.require(:id))
         end
       end

--- a/app/controllers/api/v3x0/mixins/index_mixin.rb
+++ b/app/controllers/api/v3x0/mixins/index_mixin.rb
@@ -3,6 +3,8 @@ module Api
     module Mixins
       module IndexMixin
         def index
+          authorize(filtered.new)
+
           raise_unless_primary_instance_exists
           render :json => Insights::API::Common::PaginatedResponseV2.new(
             :base_query => scoped(filtered.where(params_for_list)),

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,3 +1,8 @@
 class ApplicationPolicy < DefaultPolicy
   include ::WritePolicyMixin
+
+  def index?
+    !request.system&.cn
+  end
+  alias show? index?
 end

--- a/app/policies/authentication_policy.rb
+++ b/app/policies/authentication_policy.rb
@@ -1,3 +1,8 @@
 class AuthenticationPolicy < DefaultPolicy
   include ::WritePolicyMixin
+
+  def index?
+    !request.system&.cn
+  end
+  alias show? index?
 end


### PR DESCRIPTION
Continuing work done in #448 here

\# TODO:
- [x] disallow index/show on applications/authentications if using cn authentication
- [ ] limit index/show on source/endpoint to source_type satellite