### PR TITLE
Check if a PSK is present before checking for the x-rh-identity system key

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -2,7 +2,8 @@ class ApplicationPolicy < DefaultPolicy
   include ::WritePolicyMixin
 
   def index?
-    !request.system&.cn
+    # if the request is using psk auth it is authorized.
+    psk? || !request.system&.cn
   end
   alias show? index?
 end

--- a/app/policies/authentication_policy.rb
+++ b/app/policies/authentication_policy.rb
@@ -2,7 +2,8 @@ class AuthenticationPolicy < DefaultPolicy
   include ::WritePolicyMixin
 
   def index?
-    !request.system&.cn
+    # if the request is using psk auth it is authorized.
+    psk? || !request.system&.cn
   end
   alias show? index?
 end

--- a/app/policies/default_policy.rb
+++ b/app/policies/default_policy.rb
@@ -44,6 +44,10 @@ class DefaultPolicy
     ALLOWED_AUTHTYPES.any? { |type| request.identity["identity"]["system"].key?(type) }
   end
 
+  def psk?
+    request.headers.key?("x-rh-sources-psk")
+  end
+
   def admin?
     return true unless Sources::RBAC::Access.enabled?
 


### PR DESCRIPTION
Basically I was defaulting to a system header check in the new `index` and `show` policies for applications/authentications. This was blowing up to a 401 due to the fact that the x-rh-identity (and thus request.current) was not set and it raises an `IdentityError` exception.

This adds a check for PSK on the view operations - if it was used for auth then we are good to go. 