### PR TITLE
Migrate Authenticationt to Vault Instance

### DIFF
--- a/app/controllers/api/v1/authentications_controller.rb
+++ b/app/controllers/api/v1/authentications_controller.rb
@@ -11,6 +11,8 @@ module Api
         authentication.save!
 
         raise_event("#{model}.create", authentication.as_json)
+        VaultInterface.new(authentication).process
+
         render :json => authentication, :status => :created, :location => instance_link(authentication)
       end
     end

--- a/app/controllers/api/v3x1/bulk_create_controller.rb
+++ b/app/controllers/api/v3x1/bulk_create_controller.rb
@@ -28,6 +28,9 @@ module Api
           auth.application_authentications.each do |app_auth|
             raise_event("ApplicationAuthentication.create", app_auth.as_json)
           end
+
+          # post the newly created authentication over to vault
+          VaultInterface.new(auth).process
         end
 
         # Raising the big ole' bulk-message with all fields included.

--- a/db/migrate/20211012173623_move_authentications_to_vault.rb
+++ b/db/migrate/20211012173623_move_authentications_to_vault.rb
@@ -1,0 +1,19 @@
+class MoveAuthenticationsToVault < ActiveRecord::Migration[5.2]
+  def up
+    add_column :application_authentications, :vault_path, :string
+
+    transaction do
+      migrations, empty = Authentication.all.partition { |a| a.resource.present? }
+
+      Rails.logger.warn("Skipping #{empty.count} authentications with no resource attached.")
+
+      migrations.each do |auth|
+        VaultInterface.new(auth).process
+      end
+    end
+  end
+
+  def down
+    remove_column :application_authentications, :vault_path
+  end
+end

--- a/lib/vault_interface.rb
+++ b/lib/vault_interface.rb
@@ -1,0 +1,43 @@
+class VaultInterface
+  GO_SVC_URL = "http://#{ENV["GO_SVC"]}:#{ENV["GO_PORT"]}/api/sources/v3.1/authentications".freeze
+
+  attr_reader :authentication, :response
+
+  def initialize(authentication)
+    raise "need Go svc" unless ENV["GO_SVC"] && ENV["GO_PORT"]
+
+    @authentication = authentication
+  end
+
+  def process
+    resp = Faraday.new(GO_SVC_URL).post do |req|
+      req["content-type"] = "application/json"
+      req["x-rh-sources-account-number"] = @authentication.tenant.external_tenant
+      req["x-rh-sources-psk"] = ENV["INTERNAL_PSK"]
+
+      req.body = {
+        :resource_type             => @authentication.resource_type,
+        :resource_id               => @authentication.resource_id,
+        :name                      => @authentication.name,
+        :authtype                  => @authentication.authtype,
+        :username                  => @authentication.username,
+        :password                  => @authentication.password,
+        :extra                     => @authentication.extra,
+        :availability_status       => @authentication.availability_status,
+        :availability_status_error => @authentication.availability_status_error,
+        :last_checked_at           => @authentication.last_checked_at,
+        :last_available_at         => @authentication.last_available_at,
+        :paused_at                 => @authentication.paused_at
+      }.to_json
+    end
+
+    parsed = JSON.parse(resp.body)
+
+    raise "failed to post authentication [#{@authentication.id}] to vault: #{parsed}" if resp.status != 201
+
+    uid = parsed["id"]
+    @authentication.application_authentications.each do |appauth|
+      appauth.update!(:vault_path => "#{@authentication.resource_type}_#{authentication.resource_id}_#{uid}")
+    end
+  end
+end


### PR DESCRIPTION
:exclamation: :exclamation: :exclamation: *DO NOT MERGE UNTIL VAULT IS DEPLOYED* :exclamation: :exclamation: :exclamation: 

[RHCLOUD-15518](https://issues.redhat.com/browse/RHCLOUD-15518)

This PR has a few things in it:
1. a new service class `VaultInterface` that takes an authentication, POSTs it over to the Go service, and updates the `ApplicationAuthentication` object with the VaultPath.
2. A migration that takes all non-dangling authentications and POSTs them into the Go Service
3. Changes to `/bulk_create` and `POST /authentications` that hooks into POSTing to the Go Service after a successful create. 

\# TODO:
- [ ] add INTERNAL_PSK to ENV through the secret
- [ ] deploy vault