### PR TITLE
Superkey changes for Azure Provider

### DIFF
--- a/app/models/super_key_meta_data.rb
+++ b/app/models/super_key_meta_data.rb
@@ -1,12 +1,13 @@
 class SuperKeyMetaData < MetaData
   belongs_to :application_type
+  belongs_to :source_type
 
   default_scope { order(:step) }
 
   # required for the order of operations
   validates :step, :presence => true
   validates :name,
-            :inclusion => {:in      => ["s3", "role", "policy", "bind_role", "cost_report"],
+            :inclusion => {:in      => ["s3", "role", "policy", "bind_role", "cost_report", "lighthouse"],
                            :message => "%{value} is not a supported superkey operation"},
             :presence  => true
 
@@ -20,8 +21,11 @@ class SuperKeyMetaData < MetaData
         apptype = ApplicationType.find_by(:name => app)
 
         settings[:steps].each do |step|
+          sourcetype = SourceType.find_by(:name => step[:source_type_name])
+
           create!(
             :application_type => apptype,
+            :source_type      => sourcetype,
             :step             => step[:step],
             :name             => step[:name],
             :payload          => step[:payload],

--- a/db/migrate/20211018212220_add_source_type_to_meta_data.rb
+++ b/db/migrate/20211018212220_add_source_type_to_meta_data.rb
@@ -1,0 +1,5 @@
+class AddSourceTypeToMetaData < ActiveRecord::Migration[5.2]
+  def change
+    add_column :meta_data, :source_type_id, :integer
+  end
+end

--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -165,6 +165,25 @@ azure:
   :icon_url: "/apps/chrome/assets/images/partners-icons/microsoft-azure.svg"
   :schema:
     :authentication:
+    - :type: username_password_tenant_id
+      :is_superkey: true
+      :name: Username, Password, Tenant ID
+      :fields:
+      - :component: text-field
+        :name: authentication.authtype
+        :hideField: true
+        :initializeOnMount: true
+        :initialValue: username_password_tenant_id
+      - :component: text-field
+        :name: authentication.extra.azure.tenant_id
+        :label: Tenant ID
+      - :component: text-field
+        :name: authentication.username
+        :label: Username
+      - :component: text-field
+        :name: authentication.password
+        :label: Password
+        :type: password
     - :type: tenant_id_client_id_client_secret
       :name: Tenant ID, Client ID, Client Secret
       :fields:

--- a/db/seeds/superkey_metadata.yml
+++ b/db/seeds/superkey_metadata.yml
@@ -2,12 +2,14 @@
 "/insights/platform/cost-management":
   steps:
   - step: 1
+    source_type_name: "amazon"
     name: s3
     payload:
       "create_cost_policy"
     substitutions:
       S3BUCKET: s3
   - step: 2
+    source_type_name: "amazon"
     name: cost_report
     payload:
       {
@@ -29,6 +31,7 @@
     substitutions:
       S3BUCKET: s3
   - step: 3
+    source_type_name: "amazon"
     name: policy
     payload:
       {
@@ -60,6 +63,7 @@
     substitutions:
       S3BUCKET: s3
   - step: 4
+    source_type_name: "amazon"
     name: role
     payload:
       {
@@ -78,6 +82,7 @@
     substitutions:
       ACCOUNT: get_account
   - step: 5
+    source_type_name: "amazon"
     name: bind_role
     payload: {}
     substitutions: {}
@@ -85,6 +90,7 @@
 "/insights/platform/cloud-meter":
   steps:
   - step: 1
+    source_type_name: "amazon"
     name: policy
     payload:
       {
@@ -115,6 +121,7 @@
       }
     substitutions: {}
   - step: 2
+    source_type_name: "amazon"
     name: role
     payload:
       {
@@ -133,6 +140,14 @@
     substitutions:
       ACCOUNT: get_account
   - step: 3
+    source_type_name: "amazon"
     name: bind_role
+    payload: {}
+    substitutions: {}
+
+  # azure lighthouse settings
+  - step: 1
+    source_type_name: "azure"
+    name: "lighthouse"
     payload: {}
     substitutions: {}

--- a/lib/sources/api/messaging.rb
+++ b/lib/sources/api/messaging.rb
@@ -58,9 +58,10 @@ module Sources
       end
 
       def self.process_payload(application)
-        application.application_type.super_key_meta_data.each do |m|
-          m.payload = JSON.dump(m.payload)
-        end.as_json
+        application.application_type.super_key_meta_data
+                   .select { |e| e.source_type == application.source.source_type }
+                   .each { |m| m.payload = JSON.dump(m.payload) }
+                   .as_json
       end
     end
   end

--- a/lib/sources/super_key.rb
+++ b/lib/sources/super_key.rb
@@ -22,8 +22,11 @@ module Sources
 
           e[:account] = acct if acct
 
-          # type of authentication to return
+          # type of authentication to return - changes based on app
           e[:result_type] = @application.application_type.supported_authentication_types["amazon"]&.first
+        when "azure"
+          # azure only supports lighthouse at the moment.
+          e[:result_type] = "lighthouse_subscription_id"
         end
       end
 


### PR DESCRIPTION
Self explanatory. Did a few things:

1. Added `lighthouse` as a supported step name
2. Added a `belongs_to :source_type` to SuperKeyMetaData so we can separate steps per source type (since we only had Amazon before I didn't think of this until now). 

Other than that it follows the same patterns on superkey creation. 