### PR TITLE
fix: authtype should not be readonly

### DIFF
--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -2033,8 +2033,7 @@
         "properties": {
           "authtype": {
             "example": "openshift_default",
-            "type": "string",
-            "readOnly": true
+            "type": "string"
           },
           "availability_status": {
             "type": "string"


### PR DESCRIPTION
The authtype seems to be necessary when setting up an authentication object, therefore it shouldn't be readonly.

[[RHCLOUD-9262]](https://issues.redhat.com/browse/RHCLOUD-9262)