### PR TITLE
remove 'is_superkey: true' from the lighthouse subscription authtype

### DIFF
--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -166,7 +166,6 @@ azure:
   :schema:
     :authentication:
     - :type: lighthouse_subscription_id
-      :is_superkey: true
       :name: Subscription ID
       :fields:
       - :component: text-field


### PR DESCRIPTION
This prevents bulk_create from working - I missed it when i was pulling out all of the superkey changes for azure. 