### PR TITLE
Disable availability listener by environment variable

### DIFF
--- a/config/initializers/availability_status_listener.rb
+++ b/config/initializers/availability_status_listener.rb
@@ -2,6 +2,8 @@ require 'sources/api/clowder_config'
 
 # Be sure to restart your server when you modify this file.
 
+return if ENV['DISABLE_AVAILABILITY_STATUS_LISTENER'] == "true"
+
 # we ony want the AvailabilityStatusListener to start for the api pod, NOT the sidekiq pod.
 sidekiq_pod = Rails.env.production? && ENV['HOSTNAME'].match?(/sidekiq/)
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -167,6 +167,8 @@ objects:
               name: sources-api-secrets
               key: psks
               optional: true
+        - name: DISABLE_AVAILABILITY_STATUS_LISTENER
+          value: ${DISABLE_AVAILABILITY_STATUS_LISTENER}
         - name: DISABLE_ORG_ADMIN
           value: ${DISABLE_ORG_ADMIN}
         - name: ENCRYPTION_KEY
@@ -359,6 +361,8 @@ parameters:
   value: '1'
 - name: DISABLE_ORG_ADMIN
   description: when set to true this disables the org_admin check in the x-rh-identity.
+  value: "false"
+- name: DISABLE_AVAILABILITY_STATUS_LISTENER
   value: "false"
 - name: PROXY_REQUESTS
   description: Proxy requests from configmap to the new go-rewrite svc


### PR DESCRIPTION
Disabling and enabling is done by environment variable `DISABLE_AVAILABILITY_STATUS_LISTENER`.

`DISABLE_AVAILABILITY_STATUS_LISTENER=true` needs to be set in order to disable availability status listener.


https://issues.redhat.com/browse/RHCLOUD-16315
