### PR TITLE
[RHCLOUD-17686] feature: "ROS" as an application type for the AWS source

### DIFF
--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -41,3 +41,11 @@
   :supported_authentication_types:
     satellite:
     - receptor_node
+"/insights/platform/ros":
+  :display_name: Resource Optimization Service
+  :dependent_applications: []
+  :supported_source_types:
+    - amazon
+  :supported_authentication_types:
+    amazon:
+      - resource-optimization-service-arn

--- a/db/seeds/source_types.yml
+++ b/db/seeds/source_types.yml
@@ -65,6 +65,24 @@ amazon:
           :pattern: "^arn:aws:.*"
         - :type: min-length
           :threshold: 10
+    - :type: resource-optimization-service-arn
+      :name: Resource Optimization Service ARN
+      :fields:
+      - :component: text-field
+        :name: authentication.authtype
+        :hideField: true
+        :initializeOnMount: true
+        :initialValue: resource-optimization-service-arn
+      - :name: authentication.username
+        :component: text-field
+        :label: ARN
+        :isRequired: true
+        :validate:
+        - :type: required
+        - :type: pattern
+          :pattern: "^arn:aws:.*"
+        - :type: min-length
+          :threshold: 10
     :endpoint:
       :hidden: true
       :fields:


### PR DESCRIPTION
For now, they only support AWS, so we will leave Azure aside.

[RHCLOUD-17686](https://issues.redhat.com/browse/RHCLOUD-17686)