### PR TITLE
Lock i18 to 1.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
       graphql-batch (~> 0.3)
       promise.rb (~> 0.7)
     hashdiff (1.0.1)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     insights-api-common (5.0.7)
       acts_as_tenant


### PR DESCRIPTION
After https://github.com/RedHatInsights/sources-api/pull/473 

we need also this.


i18 1.9.0 causes https://app.travis-ci.com/github/RedHatInsights/sources-api/builds/245671018 :
```
Your bundle is locked to i18n (1.9.0) from rubygems repository
https://rubygems.org/ or installed locally, but that version can no longer be
found in that source. That means the author of i18n (1.9.0) has removed it.
You'll need to update your bundle to a version other than i18n (1.9.0) that
hasn't been removed in order to install.
```

