### PR TITLE
Add ability to disable seeding via ENV var, defaulting to false

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,9 @@
+# seeding is handled on the Go side now.
+if ENV['SKIP_SEEDING'] == "true"
+  Rails.logger.warn "Skipping seeding due to ENV"
+  exit 0
+end
+
 ApplicationType.seed
 SourceType.seed
 SuperKeyMetaData.seed

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -142,6 +142,8 @@ objects:
                 key: secret-key
           - name: SOURCES_ENV
             value: ${SOURCES_ENV}
+          - name: SKIP_SEEDING
+            value: ${SKIP_SEEDING}
         env:
         - name: APP_NAME
           value: ${APP_NAME}
@@ -373,3 +375,6 @@ parameters:
 - name: GO_PORT
   description: port of the go-rewrite svc
   value: "8000"
+- name: SKIP_SEEDING
+  description: skip the rake db:seed step since it is handled by the Go rewrite now
+  value: "false"


### PR DESCRIPTION
Self explanatory. We don't need to seed on the rails side anymore due to the Go side handling it now. 

Going to add the `SKIP_SEEDING` env var to stage as well via app-interface.