### PR TITLE
docs: return 204 when resources are paused/unpaused

### DIFF
--- a/public/doc/openapi-3-v3.1.json
+++ b/public/doc/openapi-3-v3.1.json
@@ -652,7 +652,7 @@
           }
         ],
         "responses": {
-          "202": {
+          "204": {
             "description": "Application Un-Paused"
           },
           "400": {
@@ -1656,9 +1656,9 @@
     },
     "/sources/{id}/pause": {
       "post": {
-        "summary": "Pauses a Source",
+        "summary": "Pause a source and its applications",
         "operationId": "pauseSource",
-        "description": "Pauses a Source",
+        "description": "Pauses a source and all its dependant applications",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
@@ -1666,7 +1666,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Source Paused"
+            "description": "Source and its applications paused"
           },
           "400": {
             "description": "Bad request"
@@ -1687,17 +1687,17 @@
     },
     "/sources/{id}/unpause": {
       "post": {
-        "summary": "Un-Pauses a Source",
+        "summary": "Un-Pauses a source and its applications",
         "operationId": "unpauseSource",
-        "description": "Un-Pauses a Source",
+        "description": "Un-Pauses a Source and all its dependant applications",
         "parameters": [
           {
             "$ref": "#/components/parameters/ID"
           }
         ],
         "responses": {
-          "202": {
-            "description": "Source Un-Paused"
+          "204": {
+            "description": "Source and its applications Un-Paused"
           },
           "400": {
             "description": "Bad request"


### PR DESCRIPTION
The code returns 204 "No Content"s for these endpoints, so the spec should match them. It also improves the descriptions a little bit to clarify that when pausing/resuming a source, all its applications are also paused/resumed.