### PR TITLE
[RHCLOUD-18310] feature: proxy the OpenApi spec to the Go rewrite

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -50,6 +50,9 @@ objects:
         ],
         "rhc_connections": [
           "index", "show", "create", "edit", "destroy"
+        ],
+        "root": [
+          "openapi"
         ]
       }
   kind: ConfigMap

--- a/proxy_rules/default_rules.json
+++ b/proxy_rules/default_rules.json
@@ -16,5 +16,8 @@
   ],
   "rhc_connections": [
     "index", "show", "create", "edit", "destroy"
+  ],
+  "root": [
+    "openapi"
   ]
 }


### PR DESCRIPTION
It makes sense to have the Go rewrite serving the spec, since it's the main codebase now. However, as it is not still live, we have to proxy it from the Ruby side.

## Links

[[RHCLOUD-18310]](https://issues.redhat.com/browse/RHCLOUD-18310)