### PR TITLE
tmp: bypass RBAC option enabled on ClowdApp

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -146,6 +146,8 @@ objects:
           - name: SKIP_SEEDING
             value: ${SKIP_SEEDING}
         env:
+        - name: BYPASS_RBAC
+          value: true
         - name: APP_NAME
           value: ${APP_NAME}
         - name: DB_POOL_SIZE


### PR DESCRIPTION
Bypass RBAC temporarily so that the performance team can set up the cluster without worrying about RBAC.