### PR TITLE
Revert "Merge pull request #501 from lindgrenj6/rename_clowdapp"

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: sources-api-legacy
+  name: sources-api
 objects:
 - apiVersion: v1
   kind: Secret # For ephemeral/local environment
   metadata:
     name: sources-api-secrets
     labels:
-      app: sources-api-legacy
+      app: sources-api
   stringData:
     encryption-key: "${ENCRYPTION_KEY}"
     secret-key: "${SECRET_KEY}"
@@ -18,7 +18,7 @@ objects:
   metadata:
     name: internal-psk
     labels:
-      app: sources-api-legacy
+      app: sources-api
   stringData:
     psk: "thisMustBeEphemeralOrMinikube"
 - apiVersion: v1
@@ -26,7 +26,7 @@ objects:
   metadata:
     name: sources-psk
     labels:
-      app: sources-api-legacy
+      app: sources-api
   stringData:
     psk: "thisMustBeEphemeralOrMinikube"
 - apiVersion: v1
@@ -59,11 +59,11 @@ objects:
   metadata:
     name: sources-proxy-rules
     labels:
-      app: sources-api-legacy
+      app: sources-api
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: sources-api-legacy
+    name: sources-api
   spec:
     envName: ${ENV_NAME}
     testing:

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -42,9 +42,7 @@ source $CICD_ROOT/build.sh
 # This script is used to deploy the ephemeral environment for smoke tests.
 # The manual steps for this can be found in:
 # https://internal.cloud.redhat.com/docs/devprod/ephemeral/02-deploying/
-
-# Disabling this because the IQE plugins no longer work with this after the rename.
-# source $CICD_ROOT/deploy_ephemeral_env.sh
+source $CICD_ROOT/deploy_ephemeral_env.sh
 
 # (DEPRECATED!) Run smoke tests using smoke_test.sh
 #
@@ -58,6 +56,4 @@ source $CICD_ROOT/build.sh
 # Run smoke tests using a ClowdJobInvocation (preferred)
 # The contents of this script can be found at:
 # https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd/cji_smoke_test.sh
-
-# Disabling this because the IQE plugins no longer work with this after the rename.
-# source $CICD_ROOT/cji_smoke_test.sh
+source $CICD_ROOT/cji_smoke_test.sh


### PR DESCRIPTION
This reverts commit 37e09ac3547aa87b2f30f0fad6c633b2bc3f9591, reversing
changes made to 77e2338348601aabec20b0f0c824d26384e6bf8f.

Renaming the deployment broke *all* the smoke tests that rely on us! yay!

I've locked stage to this prior commit so it is still renamed though. Will revert this revert again once we promote to prod.